### PR TITLE
Handle duplicate names in set_name!

### DIFF
--- a/src/components.jl
+++ b/src/components.jl
@@ -373,6 +373,10 @@ function set_name!(
         throw(ArgumentError("$(summary(component)) is not attached to the system"))
     end
 
+    if haskey(components.data[T], name)
+        throw(ArgumentError("A component of type $T and name = $name is already stored"))
+    end
+
     old_name = get_name(component)
     _component = components.data[T][old_name]
 

--- a/test/test_system_data.jl
+++ b/test/test_system_data.jl
@@ -54,6 +54,9 @@ end
     @test IS.get_name(component) == new_name
     @test IS.get_component(typeof(component), data, new_name) === component
 
+    IS.add_component!(data, IS.TestComponent("component2", 6))
+    @test_throws ArgumentError IS.set_name!(data, component, "component2")
+
     component2 = IS.TestComponent("unattached", 5)
     @test_throws ArgumentError IS.set_name!(data, component2, new_name)
 end


### PR DESCRIPTION
This fixes a bug where the code allowed the user to change the name of a component to a value that is already present. That caused the existing component to be silently removed from the system.

The code now detects the invalid operation and throws an exception.