### PR TITLE
Fix cases not handled in previous supplemental attribute PRs

### DIFF
--- a/src/supplemental_attribute.jl
+++ b/src/supplemental_attribute.jl
@@ -25,6 +25,13 @@ function detach_component!(
 end
 
 """
+Return true if the attribute is attached to at least one component.
+"""
+function is_attached_to_component(attribute::InfrastructureSystemsSupplementalAttribute)
+    return !isempty(get_component_uuids(attribute))
+end
+
+"""
 Return true if the attribute has time series data.
 """
 function has_time_series(attribute::InfrastructureSystemsSupplementalAttribute)

--- a/test/test_supplemental_attributes.jl
+++ b/test/test_supplemental_attributes.jl
@@ -47,6 +47,21 @@ end
     @test isempty(IS.get_component_uuids(geo_supplemental_attribute))
 end
 
+@testset "Test supplemental attribute attached to multiple components" begin
+    data = IS.SystemData()
+    geo_supplemental_attribute = IS.GeographicInfo()
+    component1 = IS.TestComponent("component1", 5)
+    component2 = IS.TestComponent("component2", 7)
+    IS.add_supplemental_attribute!(data, component1, geo_supplemental_attribute)
+    IS.add_supplemental_attribute!(data, component2, geo_supplemental_attribute)
+    @test IS.get_num_supplemental_attributes(data.attributes) == 1
+
+    IS.remove_supplemental_attribute!(data, component1, geo_supplemental_attribute)
+    @test IS.get_num_supplemental_attributes(data.attributes) == 1
+    IS.remove_supplemental_attribute!(data, component2, geo_supplemental_attribute)
+    @test IS.get_num_supplemental_attributes(data.attributes) == 0
+end
+
 @testset "Test iterate_SupplementalAttributes" begin
     container = IS.SupplementalAttributes(IS.InMemoryTimeSeriesStorage())
     geo_supplemental_attribute = IS.GeographicInfo()

--- a/test/test_system_data.jl
+++ b/test/test_system_data.jl
@@ -30,6 +30,7 @@
     IS.remove_component!(data, collect(components)[1])
     components = IS.get_components(IS.TestComponent, data)
     @test length(components) == 0
+    @test isempty(data.component_uuids)
 
     IS.add_component!(data, component)
     components = IS.get_components_by_name(IS.InfrastructureSystemsComponent, data, name)
@@ -228,6 +229,7 @@ end
     IS.check_components(data, IS.TestComponent)
     component = IS.get_component(IS.TestComponent, data, "component_3")
     IS.check_component(data, component)
+    @test component === IS.get_component(data, IS.get_uuid(component))
 end
 
 @testset "Test component and time series counts" begin
@@ -272,6 +274,7 @@ end
     end
 
     for c in IS.get_components(IS.TestComponent, data)
+        @test IS.has_supplemental_attributes(c)
         @test IS.has_supplemental_attributes(IS.GeographicInfo, c)
     end
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -50,6 +50,8 @@ struct FakeTimeSeries <: InfrastructureSystems.TimeSeriesData end
 Base.length(::FakeTimeSeries) = 42
 
 @testset "Test TimeSeriesData printing" begin
-    @test sprint(show, MIME("text/plain"), FakeTimeSeries()) ==
-          "FakeTimeSeries time_series (42):"
+    @test occursin(
+        "FakeTimeSeries time_series (42)",
+        sprint(show, MIME("text/plain"), FakeTimeSeries()),
+    )
 end


### PR DESCRIPTION
- Removal of attributes that were attached to multiple components did not work.
- Searches of components by UUID was slow. This adds an extra dictionary to provide lookup by UUID.