### PR TITLE
Updates for supplemental attributes

### DIFF
--- a/src/component.jl
+++ b/src/component.jl
@@ -269,7 +269,7 @@ function get_time_series_by_key(
     )
 end
 
-function assign_new_uuid!(component::InfrastructureSystemsComponent)
+function assign_new_uuid_internal!(component::InfrastructureSystemsComponent)
     old_uuid = get_uuid(component)
     new_uuid = make_uuid()
     if has_time_series(component)
@@ -277,11 +277,12 @@ function assign_new_uuid!(component::InfrastructureSystemsComponent)
         # There may be duplicates because of transform operations.
         changed_uuids = Set{Tuple{Base.UUID, String}}()
         for (key, ts_metadata) in container.data
-            changed_uuid = (old_uuid, key.name)
+            ts_uuid = get_time_series_uuid(ts_metadata)
+            changed_uuid = (ts_uuid, key.name)
             if !in(changed_uuid, changed_uuids)
                 replace_component_uuid!(
                     container.time_series_storage,
-                    get_time_series_uuid(ts_metadata),
+                    ts_uuid,
                     old_uuid,
                     new_uuid,
                     key.name,

--- a/src/internal.jl
+++ b/src/internal.jl
@@ -77,7 +77,7 @@ end
 """
 Assign a new UUID.
 """
-function assign_new_uuid!(obj::InfrastructureSystemsType)
+function assign_new_uuid_internal!(obj::InfrastructureSystemsType)
     get_internal(obj).uuid = make_uuid()
     return
 end

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -955,12 +955,12 @@ end
 _get_system_basename(system_file) = splitext(basename(system_file))[1]
 _get_secondary_basename(system_basename, name) = system_basename * "_" * name
 
-function add_supplemental_attribute!(data::SystemData, component, info; kwargs...)
+function add_supplemental_attribute!(data::SystemData, component, attribute; kwargs...)
     if isnothing(get_component(typeof(component), data, get_name(component)))
         throw(ArgumentError("$(summary(component)) is not attached to the system"))
     end
 
-    return add_supplemental_attribute!(data.attributes, component, info; kwargs...)
+    return add_supplemental_attribute!(data.attributes, component, attribute; kwargs...)
 end
 
 function get_supplemental_attributes(

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -866,6 +866,11 @@ end
 get_components_by_name(::Type{T}, data::SystemData, args...) where {T} =
     get_components_by_name(T, data.components, args...)
 
+function get_components(data::SystemData, attribute::SupplementalAttribute)
+    uuids = get_component_uuids(attribute)
+    return [get_component(data, x) for x in uuids]
+end
+
 function get_masked_components(
     ::Type{T},
     data::SystemData,
@@ -950,8 +955,13 @@ end
 _get_system_basename(system_file) = splitext(basename(system_file))[1]
 _get_secondary_basename(system_basename, name) = system_basename * "_" * name
 
-add_supplemental_attribute!(data::SystemData, component, info; kwargs...) =
-    add_supplemental_attribute!(data.attributes, component, info; kwargs...)
+function add_supplemental_attribute!(data::SystemData, component, info; kwargs...)
+    if isnothing(get_component(typeof(component), data, get_name(component)))
+        throw(ArgumentError("$(summary(component)) is not attached to the system"))
+    end
+
+    return add_supplemental_attribute!(data.attributes, component, info; kwargs...)
+end
 
 function get_supplemental_attributes(
     filter_func::Function,

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -390,8 +390,12 @@ end
 """
 Removes the component from the main container and adds it to the masked container.
 """
-function mask_component!(data::SystemData, component::InfrastructureSystemsComponent)
-    remove_component!(data.components, component; remove_time_series = false)
+function mask_component!(
+    data::SystemData,
+    component::InfrastructureSystemsComponent;
+    remove_time_series = false,
+)
+    remove_component!(data.components, component; remove_time_series = remove_time_series)
     set_time_series_storage!(component, nothing)
     return add_masked_component!(
         data,
@@ -833,6 +837,17 @@ function get_component(data::SystemData, uuid::Base.UUID)
     end
 
     return component
+end
+
+function assign_new_uuid!(data::SystemData, component::InfrastructureSystemsComponent)
+    orig_uuid = get_uuid(component)
+    if isnothing(pop!(data.component_uuids, orig_uuid, nothing))
+        throw(ArgumentError("component with uuid = $orig_uuid is not stored."))
+    end
+
+    assign_new_uuid_internal!(component)
+    data.component_uuids[get_uuid(component)] = component
+    return
 end
 
 function get_components(filter_func::Function, ::Type{T}, data::SystemData) where {T}

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -491,7 +491,7 @@ function copy_time_series!(
             @debug "Copy ts_metadata with" _group = LOG_GROUP_TIME_SERIES new_multiplier
         end
         new_time_series = deepcopy(ts_metadata)
-        assign_new_uuid!(new_time_series)
+        assign_new_uuid_internal!(new_time_series)
         set_name!(new_time_series, new_name)
         set_scaling_factor_multiplier!(new_time_series, new_multiplier)
         add_time_series!(dst, new_time_series)

--- a/test/test_internal.jl
+++ b/test/test_internal.jl
@@ -1,7 +1,7 @@
-@testset "Test assign_new_uuid" begin
+@testset "Test assign_new_uuid_internal" begin
     component = IS.TestComponent("component", 5)
     uuid1 = IS.get_uuid(component)
-    IS.assign_new_uuid!(component)
+    IS.assign_new_uuid_internal(component)
     @test uuid1 != IS.get_uuid(component)
 end
 

--- a/test/test_internal.jl
+++ b/test/test_internal.jl
@@ -1,7 +1,7 @@
 @testset "Test assign_new_uuid_internal" begin
     component = IS.TestComponent("component", 5)
     uuid1 = IS.get_uuid(component)
-    IS.assign_new_uuid_internal(component)
+    IS.assign_new_uuid_internal!(component)
     @test uuid1 != IS.get_uuid(component)
 end
 

--- a/test/test_supplemental_attributes.jl
+++ b/test/test_supplemental_attributes.jl
@@ -52,6 +52,8 @@ end
     geo_supplemental_attribute = IS.GeographicInfo()
     component1 = IS.TestComponent("component1", 5)
     component2 = IS.TestComponent("component2", 7)
+    IS.add_component!(data, component1)
+    IS.add_component!(data, component2)
     IS.add_supplemental_attribute!(data, component1, geo_supplemental_attribute)
     IS.add_supplemental_attribute!(data, component2, geo_supplemental_attribute)
     @test IS.get_num_supplemental_attributes(data.attributes) == 1

--- a/test/test_system_data.jl
+++ b/test/test_system_data.jl
@@ -311,6 +311,15 @@ end
     attr2 = IS.TestSupplemental(; value = 2.0)
     component1 = IS.TestComponent("component1", 5)
     component2 = IS.TestComponent("component2", 7)
+
+    @test_throws ArgumentError IS.add_supplemental_attribute!(
+        data,
+        component1,
+        geo_supplemental_attribute,
+    )
+
+    IS.add_component!(data, component1)
+    IS.add_component!(data, component2)
     IS.add_supplemental_attribute!(data, component1, geo_supplemental_attribute)
     IS.add_supplemental_attribute!(data, component2, geo_supplemental_attribute)
     IS.add_supplemental_attribute!(data, component1, attr1)
@@ -393,4 +402,20 @@ end
           IS.get_supplemental_attribute(component1, uuid3)
     @test IS.get_supplemental_attribute(data, uuid3) ===
           IS.get_supplemental_attribute(component2, uuid3)
+end
+
+@testset "Test retrieval of components with a supplemental attribute" begin
+    data = IS.SystemData()
+    geo_supplemental_attribute = IS.GeographicInfo()
+    component1 = IS.TestComponent("component1", 5)
+    component2 = IS.TestComponent("component2", 7)
+    IS.add_component!(data, component1)
+    IS.add_component!(data, component2)
+    IS.add_supplemental_attribute!(data, component1, geo_supplemental_attribute)
+    IS.add_supplemental_attribute!(data, component2, geo_supplemental_attribute)
+    components = IS.get_components(data, geo_supplemental_attribute)
+    @test length(components) == 2
+    sort!(components; by = x -> x.name)
+    @test components[1] === component1
+    @test components[2] === component2
 end

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -2203,7 +2203,7 @@ end
     end
 end
 
-@testset "Test assign_new_uuid! for component with time series" begin
+@testset "Test assign_new_uuid_internal! for component with time series" begin
     for in_memory in (true, false)
         sys = IS.SystemData(; time_series_in_memory = in_memory)
         name = "Component1"
@@ -2225,7 +2225,7 @@ end
               IS.SingleTimeSeries
 
         old_uuid = IS.get_uuid(component)
-        IS.assign_new_uuid!(component)
+        IS.assign_new_uuid_internal!(component)
         new_uuid = IS.get_uuid(component)
         @test old_uuid != new_uuid
 


### PR DESCRIPTION
This PR adds these items:
1. Fix handling of `assign_new_uuid`. The function now has to go through the system because of the UUID dictionary that we are managing.
2. Add a function to get all components attached to a supplemental attribute.