### PR TITLE
Fix reading of 2d time series data in test code

### DIFF
--- a/src/hdf5_time_series_storage.jl
+++ b/src/hdf5_time_series_storage.jl
@@ -354,7 +354,7 @@ function iterate_time_series(storage::Hdf5TimeSeriesStorage)
         HDF5.h5open(storage.file_path, "r") do file
             root = _get_root(storage, file)
             for uuid_group in root
-                data = uuid_group["data"][:]
+                data = HDF5.read(uuid_group["data"])
                 attributes = Dict()
                 for name in keys(HDF5.attributes(uuid_group))
                     attributes[name] = HDF5.read(HDF5.attributes(uuid_group)[name])


### PR DESCRIPTION
This function, which is only used in tests, was not handling time series data with multiple dimensions.

This is a very old bug. It was triggered by the addition of supplemental attributes and outages to PowerSystem.jl. Tests for those features started using a system with 2-dimensional time series data. That code worked when in-memory time series data used, which happens in PowerSystemCaseBuilder when you set build_system(force_build=true).