### PR TITLE
Variable Cost Refactor Part 2: PowerSimulations

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -24,3 +24,4 @@ end
 
 const CONSTANT = Float64
 const LIM_TOL = 1e-6
+const XY_COORDS = @NamedTuple{x::Float64, y::Float64}

--- a/src/function_data.jl
+++ b/src/function_data.jl
@@ -64,10 +64,10 @@ representation of cost functions where the points store quantities (x, y), such 
 The curve starts at the first point given, not the origin.
 
 # Arguments
- - `points::Vector{@NamedTuple{x::Float64, y::Float64}}`: the points that define the function
+ - `points::Vector{XY_COORDS}`: the points that define the function
 """
 struct PiecewiseLinearPointData <: FunctionData
-    points::Vector{@NamedTuple{x::Float64, y::Float64}}
+    points::Vector{XY_COORDS}
 
     function PiecewiseLinearPointData(points::Vector{<:NamedTuple{(:x, :y)}})
         _validate_piecewise_x(first.(points))
@@ -83,7 +83,7 @@ function PiecewiseLinearPointData(points::Vector{<:NamedTuple})
     )
 end
 
-function _convert_to_xy(point)
+function _convert_to_xy_coords(point)
     # Need to be able to handle dicts for deserialization
     if point isa AbstractDict
         (keys(point) == Set(["x", "y"])) && return (x = point["x"], y = point["y"])
@@ -97,7 +97,7 @@ function _convert_to_xy(point)
 end
 
 function PiecewiseLinearPointData(points::Vector)
-    PiecewiseLinearPointData(_convert_to_xy.(points))
+    PiecewiseLinearPointData(_convert_to_xy_coords.(points))
 end
 
 "Get the points that define the piecewise data"
@@ -106,7 +106,7 @@ get_points(data::PiecewiseLinearPointData) = data.points
 "Get the x-coordinates of the points that define the piecewise data"
 get_x_coords(data::PiecewiseLinearPointData) = first.(get_points(data))
 
-function _get_slopes(vc::Vector{@NamedTuple{x::Float64, y::Float64}})
+function _get_slopes(vc::Vector{XY_COORDS})
     slopes = Vector{Float64}(undef, length(vc) - 1)
     (prev_x, prev_y) = vc[1]
     for (i, (comp_x, comp_y)) in enumerate(vc[2:end])
@@ -163,7 +163,7 @@ get_y0(data::PiecewiseLinearSlopeData) = data.y0
 function get_points(data::PiecewiseLinearSlopeData)
     slopes = get_slopes(data)
     x_coords = get_x_coords(data)
-    points = Vector{@NamedTuple{x::Float64, y::Float64}}(undef, length(x_coords))
+    points = Vector{XY_COORDS}(undef, length(x_coords))
     running_y = get_y0(data)
     points[1] = (x = x_coords[1], y = running_y)
     for (i, (prev_slope, this_x, dx)) in

--- a/test/test_function_data.jl
+++ b/test/test_function_data.jl
@@ -62,7 +62,7 @@ end
         [1, 10])
 
     @test IS.get_points(IS.PiecewiseLinearSlopeData([1, 3, 5], 1, [2.5, 10])) isa
-          Vector{@NamedTuple{x::Float64, y::Float64}}
+          Vector{IS.XY_COORDS}
     @test isapprox(
         collect.(IS.get_points(IS.PiecewiseLinearSlopeData([1, 3, 5], 1, [2.5, 10]))),
         collect.([(1, 1), (3, 6), (5, 26)]),

--- a/test/test_function_data.jl
+++ b/test/test_function_data.jl
@@ -9,6 +9,11 @@ get_test_function_data() = [
 @testset "Test FunctionData validation" begin
     @test_throws ArgumentError IS.PiecewiseLinearPointData([(2, 1), (1, 1)])
     @test_throws ArgumentError IS.PiecewiseLinearSlopeData([2, 1], 1, [1])
+
+    @test IS.PiecewiseLinearPointData([(x = 1, y = 1)]) isa Any  # Test absence of error
+    @test IS.PiecewiseLinearPointData([Dict("x" => 1, "y" => 1)]) isa Any
+    @test_throws ArgumentError IS.PiecewiseLinearPointData([(y = 1, x = 1)])
+    @test_throws ArgumentError IS.PiecewiseLinearPointData([Dict("x" => 1)])
 end
 
 @testset "Test FunctionData trivial getters" begin
@@ -26,7 +31,7 @@ end
     @test coeffs[0] === 3.0 && coeffs[1] === 1.0 && coeffs[3] === 4.0
 
     yd = IS.PiecewiseLinearPointData([(1, 1), (3, 5)])
-    @test IS.get_points(yd) == [(1, 1), (3, 5)]
+    @test IS.get_points(yd) == [(x = 1, y = 1), (x = 3, y = 5)]
 
     dd = IS.PiecewiseLinearSlopeData([1, 3, 5], 2, [3, 6])
     @test IS.get_x_coords(dd) == [1, 3, 5]
@@ -38,7 +43,7 @@ end
     @test length(IS.PiecewiseLinearPointData([(0, 0), (1, 1), (1.1, 2)])) == 2
     @test length(IS.PiecewiseLinearSlopeData([1, 1.1, 1.2], 1, [1.1, 10])) == 2
 
-    @test IS.PiecewiseLinearPointData([(0, 0), (1, 1), (1.1, 2)])[2] == (1, 1)
+    @test IS.PiecewiseLinearPointData([(0, 0), (1, 1), (1.1, 2)])[2] == (x = 1, y = 1)
     @test IS.get_x_coords(IS.PiecewiseLinearPointData([(0, 0), (1, 1), (1.1, 2)])) ==
           [0, 1, 1.1]
 
@@ -56,6 +61,8 @@ end
         IS.get_slopes(IS.PiecewiseLinearPointData([(0, 0), (1, 1), (1.1, 2)])),
         [1, 10])
 
+    @test IS.get_points(IS.PiecewiseLinearSlopeData([1, 3, 5], 1, [2.5, 10])) isa
+          Vector{@NamedTuple{x::Float64, y::Float64}}
     @test isapprox(
         collect.(IS.get_points(IS.PiecewiseLinearSlopeData([1, 3, 5], 1, [2.5, 10]))),
         collect.([(1, 1), (3, 6), (5, 26)]),
@@ -84,7 +91,7 @@ end
         pointwise = IS.PiecewiseLinearPointData(collect(zip(rand_x, rand_y)))
         slopewise = IS.PiecewiseLinearSlopeData(
             IS.get_x_coords(pointwise),
-            first(IS.get_points(pointwise))[2],
+            first(IS.get_points(pointwise)).y,
             IS.get_slopes(pointwise))
         pointwise_2 = IS.PiecewiseLinearPointData(IS.get_points(slopewise))
         @test isapprox(

--- a/test/test_function_data.jl
+++ b/test/test_function_data.jl
@@ -110,3 +110,22 @@ end
         end
     end
 end
+
+@testset "Test FunctionData raw data" begin
+    raw_data_answers = [
+        5.0,
+        (2.0, 3.0, 4.0),
+        [(0, 3.0), (1, 1.0), (3, 4.0)],
+        [(1.0, 1.0), (3.0, 5.0), (5.0, 10.0)],
+        [(1.0, 1.0), (3.0, 2.0), (5.0, 2.5)],
+    ]
+    for (fd, answer) in zip(get_test_function_data(), raw_data_answers)
+        @test IS.get_raw_data_type(fd) == typeof(answer)
+    end
+    for (fd, answer) in zip(get_test_function_data(), raw_data_answers)
+        @test IS.get_raw_data_type(typeof(fd)) == typeof(answer)
+    end
+    for (fd, answer) in zip(get_test_function_data(), raw_data_answers)
+        @test IS.get_raw_data(fd) == answer
+    end
+end


### PR DESCRIPTION
The second part of a significant refactor of Sienna cost data structures (part 1 is [here](https://github.com/NREL-Sienna/PowerSystems.jl/pull/1056#issuecomment-1959057500)). The main focus here is to bring PowerSimulations.jl up to date with the elimination of `VariableCost` in favor of `FunctionData`. That entails these changes in InfrastructureSystems:

- Make `PiecewiseLinearPointData` use `NamedTuples` so it's even harder to mix up x and y
- Add the notion of "raw data" to support storing data from `FunctionData` in other containers, like the ones in PowerSimulations

On the latter point — does this functionality belong in PowerSimulations?

Tests pass:
<img width="1635" alt="Screenshot 2024-02-26 at 4 32 27 AM" src="https://github.com/NREL-Sienna/InfrastructureSystems.jl/assets/23368820/8c27f79b-1f06-4a81-8344-1a78e4ef76ad">
