### PR TITLE
Add functionality to serialize a system without time series

### DIFF
--- a/src/components.jl
+++ b/src/components.jl
@@ -356,14 +356,20 @@ function set_name!(
     return
 end
 
-function compare_values(x::Components, y::Components; compare_uuids = false)
+function compare_values(
+    x::Components,
+    y::Components;
+    compare_uuids = false,
+    exclude = Set{Symbol}(),
+)
     match = true
     for name in fieldnames(Components)
+        name in exclude && continue
         # This gets validated in SystemData.
         name == :time_series_storage && continue
         val_x = getfield(x, name)
         val_y = getfield(y, name)
-        if !compare_values(val_x, val_y; compare_uuids = compare_uuids)
+        if !compare_values(val_x, val_y; compare_uuids = compare_uuids, exclude = exclude)
             @error "Components field = $name does not match" val_x val_y
             match = false
         end

--- a/src/hdf5_time_series_storage.jl
+++ b/src/hdf5_time_series_storage.jl
@@ -795,6 +795,7 @@ function compare_values(
     x::Hdf5TimeSeriesStorage,
     y::Hdf5TimeSeriesStorage;
     compare_uuids = false,
+    kwargs...,
 )
     item_x = sort!(collect(iterate_time_series(x)); by = z -> z[1])
     item_y = sort!(collect(iterate_time_series(y)); by = z -> z[1])

--- a/src/in_memory_time_series_storage.jl
+++ b/src/in_memory_time_series_storage.jl
@@ -230,6 +230,7 @@ function compare_values(
     x::InMemoryTimeSeriesStorage,
     y::InMemoryTimeSeriesStorage;
     compare_uuids = false,
+    kwargs...,
 )
     keys_x = sort!(collect(keys(x.data)))
     keys_y = sort!(collect(keys(y.data)))

--- a/src/internal.jl
+++ b/src/internal.jl
@@ -112,10 +112,11 @@ function compare_values(
     x::InfrastructureSystemsInternal,
     y::InfrastructureSystemsInternal;
     compare_uuids = false,
+    exclude = Set{Symbol}(),
 )
     match = true
     for name in fieldnames(InfrastructureSystemsInternal)
-        if name == :uuid && !compare_uuids
+        if name in exclude || (name == :uuid && !compare_uuids)
             continue
         end
         if name == :ext
@@ -127,7 +128,7 @@ function compare_values(
             if val2 isa Dict && isempty(val2)
                 val2 = nothing
             end
-            if !compare_values(val1, val2; compare_uuids = compare_uuids)
+            if !compare_values(val1, val2; compare_uuids = compare_uuids, exclude = exclude)
                 @error "ext does not match" val1 val2
                 match = false
             end
@@ -135,6 +136,7 @@ function compare_values(
             getfield(x, name),
             getfield(y, name);
             compare_uuids = compare_uuids,
+            exclude = exclude,
         )
             @error "InfrastructureSystemsInternal field=$name does not match"
             match = false

--- a/test/test_serialization.jl
+++ b/test/test_serialization.jl
@@ -8,7 +8,7 @@ function validate_serialization(sys::IS.SystemData; time_series_read_only = fals
         if isfile(filename)
             rm(filename)
         end
-        IS.prepare_for_serialization!(sys, filename; force = true)
+        IS.prepare_for_serialization_to_file!(sys, filename; force = true)
         data = IS.serialize(sys)
         open(filename, "w") do io
             return JSON3.write(io, data)
@@ -29,8 +29,6 @@ function validate_serialization(sys::IS.SystemData; time_series_read_only = fals
     else
         @test !isfile(t_file)
     end
-    v_file = splitext(basename(path))[1] * "_" * IS.VALIDATION_DESCRIPTOR_FILE
-    mv(v_file, joinpath(test_dir, v_file))
 
     data = open(path) do io
         return JSON3.read(io, Dict)
@@ -66,11 +64,12 @@ end
     end
 end
 
-@testset "Test prepare_for_serialization" begin
+@testset "Test prepare_for_serialization_to_file" begin
     sys = create_system_data_shared_time_series()
     directory = joinpath(mktempdir(), "dir2")
-    IS.prepare_for_serialization!(sys, joinpath(directory, "sys.json"))
-    @test IS.get_ext(sys.internal)["serialization_directory"] == directory
+    IS.prepare_for_serialization_to_file!(sys, joinpath(directory, "sys.json"))
+    @test IS.get_ext(sys.internal)[IS.SERIALIZATION_METADATA_KEY]["serialization_directory"] ==
+          directory
 end
 
 @testset "Test JSON serialization of with read-only time series" begin


### PR DESCRIPTION
There are three sets of changes here:
1. Add a `to_dict` method so that the IS system and components can be serialized to a JSON string without the time series data.
2. Remove serialization of a system’s validation descriptors. This is a breaking change in that any custom packages that were defining their own validation descriptors will need to pass them at deserialization time (there probably aren’t any). This actually fixes an issue where the descriptors were not upgraded by PSY during an upgrade across major versions.
3. Update the test code that compares objects recursively to exclude comparison of time series fields that will not be valid in this scenario.