### PR TITLE
Resolve nameof vs strip_module_name

### DIFF
--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -985,7 +985,7 @@ set_name!(data::SystemData, component, name) = set_name!(data.components, compon
 function get_component_counts_by_type(data::SystemData)
     counts = Dict{String, Int}()
     for (component_type, components) in data.components.data
-        counts[string(nameof(component_type))] = length(components)
+        counts[strip_module_name(component_type)] = length(components)
     end
 
     return [

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -166,7 +166,7 @@ function Base.show(io::IO, ::MIME"text/plain", ist::InfrastructureSystemsCompone
 end
 
 function Base.show(io::IO, ist::InfrastructureSystemsComponent)
-    print(io, string(nameof(typeof(ist))), "(")
+    print(io, strip_module_name(typeof(ist)), "(")
     is_first = true
     for (name, field_type) in zip(fieldnames(typeof(ist)), fieldtypes(typeof(ist)))
         if field_type <: TimeSeriesContainer || field_type <: InfrastructureSystemsInternal
@@ -210,7 +210,7 @@ function show_container_table(io::IO, container::InfrastructureSystemsContainer;
     header = ["Type", "Count", "Has Static Time Series", "Has Forecasts"]
     data = Array{Any, 2}(undef, length(container.data), length(header))
 
-    type_names = [(string(nameof(x)), x) for x in keys(container.data)]
+    type_names = [(strip_module_name(x), x) for x in keys(container.data)]
     sort!(type_names; by = x -> x[1])
     for (i, (type_name, type)) in enumerate(type_names)
         vals = container.data[type]
@@ -248,7 +248,7 @@ function show_components(
         error("$component_type must be a concrete type")
     end
 
-    title = string(nameof(component_type))
+    title = strip_module_name(component_type)
     header = ["name"]
     has_available = false
     if :available in fieldnames(component_type)

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -60,7 +60,19 @@ function supertypes(::Type{T}, types = []) where {T}
 end
 
 """
-Strips the module name off of a type.
+Strips the module name off of a type. This can be useful to print types as strings and
+receive consistent results regardless of whether the user used `import` or `using` to
+load a package.
+
+Unlike Base.nameof, this function preserves any parametric types.
+
+# Examples
+```julia-repl
+julia> strip_module_name(PowerSystems.RegulationDevice{ThermalStandard})
+"RegulationDevice{ThermalStandard}"
+julia> string(nameof(PowerSystems.RegulationDevice{ThermalStandard}))
+"RegulationDevice"
+```
 """
 function strip_module_name(name::String)
     index = findfirst(".", name)
@@ -79,16 +91,6 @@ end
 
 function strip_module_name(::Type{T}) where {T}
     return strip_module_name(string(T))
-end
-
-function strip_parametric_type(name::AbstractString)
-    index = findfirst("{", name)
-    if !isnothing(index)
-        # Ignore the parametric type.
-        name = name[1:(index.start - 1)]
-    end
-
-    return name
 end
 
 """
@@ -297,7 +299,7 @@ function forward(sender::Tuple{Type, Symbol}, ::Type, method::Method)
     # Assert that function name always starts with `get_*`
     "`forward` only works for accessor methods that are defined as `get_*` or `set_*`"
     @assert startswith(string(method.name), r"set_|get_")
-    sender_type = "$(parentmodule(sender[1])).$(strip_module_name(sender[1]))"
+    sender_type = string(sender[1])
     sender_symbol = string(sender[2])
     code_array = Vector{String}()
     # Search for receiver type in method arguments

--- a/src/validation.jl
+++ b/src/validation.jl
@@ -70,7 +70,7 @@ function validate_fields(
     components::Components,
     ist_struct::T,
 ) where {T <: InfrastructureSystemsType}
-    type_name = strip_parametric_type(string(nameof(T)))
+    type_name = string(nameof(T))
     struct_descriptor = get_config_descriptor(components.validation_descriptors, type_name)
     isnothing(struct_descriptor) && return true
     is_valid = true

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -14,15 +14,6 @@ end
           "SingleTimeSeries{PowerSystems.HydroDispatch}"
 end
 
-@testset "Test strip_parametric_type" begin
-    @test IS.strip_parametric_type("SingleTimeSeries{PowerSystems.HydroDispatch}") ==
-          "SingleTimeSeries"
-
-    @test IS.strip_parametric_type(
-        "InfrastructureSystems.SingleTimeSeries{PowerSystems.HydroDispatch}",
-    ) == "InfrastructureSystems.SingleTimeSeries"
-end
-
 @testset "Test exported names" begin
     @test IS.validate_exported_names(IS)
 end


### PR DESCRIPTION
This is a follow-on to #339. There were cases where we were using `nameof` (which removes parameteric types) where we should have used `strip_module_name` (which preserves parametric types). The best example is when printing a table of component counts. We were showing `VariableReserve` twice instead of showing both `VariableReserve{ReserveDown}` and `VariableReserve{ReserveUp}`.