### PR TITLE
Allow bulk writing and reading of time series

### DIFF
--- a/docs/src/dev_guide/time_series.md
+++ b/docs/src/dev_guide/time_series.md
@@ -27,6 +27,9 @@ deserialize the system.
 
   - Time series data can optionally be stored fully in memory. Refer to the [`InfrastructureSystems.SystemData`](@ref) documentation.
   - `InfrastructureSystems.jl` creates HDF5 files on the tmp filesystem by default, using the location obtained from `tempdir()`. This can be changed if the time series data is larger than the amount of tmp space available. Refer to the [`InfrastructureSystems.SystemData`](@ref) link above.
+  - By default, the call to `add_time_series!` will open the .h5 file, write the data to the file,
+  and close the file. Opening and closing the file has overhead. If you will add thousands of time
+  series arrays, consider using `open_time_series_store!` to add all the arrays with one file handle.
 
 ## Instructions
 

--- a/src/in_memory_time_series_storage.jl
+++ b/src/in_memory_time_series_storage.jl
@@ -37,6 +37,16 @@ function InMemoryTimeSeriesStorage(hdf5_storage::Hdf5TimeSeriesStorage)
     return storage
 end
 
+function open_store!(
+    func::Function,
+    store::InMemoryTimeSeriesStorage,
+    mode = "r",
+    args...;
+    kwargs...,
+)
+    func(args...; kwargs...)
+end
+
 Base.isempty(storage::InMemoryTimeSeriesStorage) = isempty(storage.data)
 
 check_read_only(storage::InMemoryTimeSeriesStorage) = nothing

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -108,6 +108,16 @@ function SystemData(
     )
 end
 
+function open_time_series_store!(
+    func::Function,
+    data::SystemData,
+    mode = "r",
+    args...;
+    kwargs...,
+)
+    open_store!(func, data.time_series_storage, mode, args...; kwargs...)
+end
+
 """
 Adds time_series from a metadata file or metadata descriptors.
 
@@ -144,10 +154,12 @@ function add_time_series_from_file_metadata!(
     file_metadata::Vector{TimeSeriesFileMetadata};
     resolution = nothing,
 ) where {T <: InfrastructureSystemsComponent}
-    cache = TimeSeriesParsingCache()
-    for metadata in file_metadata
-        if resolution === nothing || metadata.resolution == resolution
-            add_time_series_from_file_metadata_internal!(data, T, cache, metadata)
+    open_time_series_store!(data, "r+") do
+        cache = TimeSeriesParsingCache()
+        for metadata in file_metadata
+            if resolution === nothing || metadata.resolution == resolution
+                add_time_series_from_file_metadata_internal!(data, T, cache, metadata)
+            end
         end
     end
     return


### PR DESCRIPTION
This is at least a partial fix of https://github.com/NREL-Sienna/PowerSystems.jl/issues/1076. The current behavior is to open and close the file once per addition of a time series array. The open/close has non-trivial overhead.

This PR allows the user to open the store for bulk writes and reads.

There may be other performance issues experienced by the submitter. I’d like to see what happens with this change by itself.  

This PR is targeted at main. We could easily backport it to the current IS/PSY tags.