### PR TITLE
Share time series data on a component across multiple fields

### DIFF
--- a/src/deterministic.jl
+++ b/src/deterministic.jl
@@ -194,6 +194,28 @@ function Deterministic(forecast::Deterministic, data)
     return Deterministic(; vals...)
 end
 
+"""
+Construct Deterministic that shares the data from an existing instance.
+
+This is useful in cases where you want a component to use the same time series data for
+two different attributes.
+"""
+function Deterministic(
+    src::Deterministic,
+    name::AbstractString;
+    scaling_factor_multiplier::Union{Nothing, Function} = nothing,
+)
+    # units and ext are not copied
+    internal = InfrastructureSystemsInternal(; uuid = get_uuid(src))
+    return Deterministic(
+        name,
+        src.data,
+        src.resolution,
+        scaling_factor_multiplier,
+        internal,
+    )
+end
+
 convert_data(
     data::AbstractDict{<:Any, Vector{T}},
 ) where {T <: Union{CONSTANT, FunctionData}} =

--- a/src/probabilistic.jl
+++ b/src/probabilistic.jl
@@ -181,6 +181,29 @@ function Probabilistic(info::TimeSeriesParsedInfo)
     )
 end
 
+"""
+Construct a Probabilistic that shares the data from an existing instance.
+
+This is useful in cases where you want a component to use the same time series data for
+two different attributes.
+"""
+function Probabilistic(
+    src::Probabilistic,
+    name::AbstractString;
+    scaling_factor_multiplier::Union{Nothing, Function} = nothing,
+)
+    # units and ext are not copied
+    internal = InfrastructureSystemsInternal(; uuid = get_uuid(src))
+    return Probabilistic(
+        name,
+        src.data,
+        src.percentiles,
+        src.resolution,
+        scaling_factor_multiplier,
+        internal,
+    )
+end
+
 function ProbabilisticMetadata(time_series::Probabilistic)
     return ProbabilisticMetadata(
         get_name(time_series),

--- a/src/scenarios.jl
+++ b/src/scenarios.jl
@@ -126,6 +126,29 @@ function Scenarios(
     )
 end
 
+"""
+Construct Scenarios that shares the data from an existing instance.
+
+This is useful in cases where you want a component to use the same time series data for
+two different attributes.
+"""
+function Scenarios(
+    src::Scenarios,
+    name::AbstractString;
+    scaling_factor_multiplier::Union{Nothing, Function} = nothing,
+)
+    # units and ext are not copied
+    internal = InfrastructureSystemsInternal(; uuid = get_uuid(src))
+    return Scenarios(
+        name,
+        src.data,
+        src.scenario_count,
+        src.resolution,
+        scaling_factor_multiplier,
+        internal,
+    )
+end
+
 function Scenarios(ts_metadata::ScenariosMetadata, data::SortedDict)
     return Scenarios(;
         name = get_name(ts_metadata),

--- a/src/single_time_series.jl
+++ b/src/single_time_series.jl
@@ -44,6 +44,28 @@ function SingleTimeSeries(;
     )
 end
 
+"""
+Construct SingleTimeSeries that shares the data from an existing instance.
+
+This is useful in cases where you want a component to use the same time series data for
+two different attribtues.
+"""
+function SingleTimeSeries(
+    src::SingleTimeSeries,
+    name::AbstractString;
+    scaling_factor_multiplier::Union{Nothing, Function} = nothing,
+)
+    # units and ext are not copied
+    internal = InfrastructureSystemsInternal(; uuid = get_uuid(src))
+    return SingleTimeSeries(
+        name,
+        src.data,
+        src.resolution,
+        scaling_factor_multiplier,
+        internal,
+    )
+end
+
 function _get_resolution(data::TimeSeries.TimeArray)
     if length(data) < 2
         throw(

--- a/src/time_series_formats.jl
+++ b/src/time_series_formats.jl
@@ -27,7 +27,7 @@ function read_time_series(
     @debug "Read CSV data from $(data_file)." _group = LOG_GROUP_TIME_SERIES
 
     format = get_time_series_format(file)
-    @debug "$format detected for the time series" _group = LOG_GROUP_TIME_SERIES
+    @debug "$format detected for the time series" T _group = LOG_GROUP_TIME_SERIES
     return read_time_series(format, T, file, component_name; kwargs...)
 end
 

--- a/src/time_series_parser.jl
+++ b/src/time_series_parser.jl
@@ -117,7 +117,6 @@ function read_time_series_file_metadata(file_path::AbstractString)
         csv = DataFrames.DataFrame(CSV.File(file_path))
         metadata = Vector{TimeSeriesFileMetadata}()
         for row in eachrow(csv)
-            category = row.category
             scaling_factor_multiplier = get(row, :scaling_factor_multiplier, nothing)
             scaling_factor_multiplier_module =
                 get(row, :scaling_factor_multiplier_module, nothing)
@@ -255,7 +254,7 @@ function TimeSeriesParsedInfo(metadata::TimeSeriesFileMetadata, raw_data::RawTim
             normalization_factor = NormalizationTypes.MAX
         else
             factor = metadata.normalization_factor
-            throw(DataFormatError("unsupported normalization_factor {factor}"))
+            throw(DataFormatError("unsupported normalization_factor $factor"))
         end
     elseif metadata.normalization_factor == 0.0
         throw(DataFormatError("unsupported normalization_factor value of 0.0"))

--- a/src/utils/test.jl
+++ b/src/utils/test.jl
@@ -1,15 +1,17 @@
 mutable struct TestComponent <: InfrastructureSystemsComponent
     name::String
     val::Int
+    val2::Int
     time_series_container::TimeSeriesContainer
     supplemental_attributes_container::SupplementalAttributesContainer
     internal::InfrastructureSystemsInternal
 end
 
-function TestComponent(name, val)
+function TestComponent(name, val; val2 = 0)
     return TestComponent(
         name,
         val,
+        val2,
         TimeSeriesContainer(),
         SupplementalAttributesContainer(),
         InfrastructureSystemsInternal(),
@@ -51,6 +53,7 @@ end
 get_internal(component::TestComponent) = component.internal
 get_internal(component::AdditionalTestComponent) = component.internal
 get_val(component::TestComponent) = component.val
+get_val2(component::TestComponent) = component.val2
 get_supplemental_attributes_container(component::TestComponent) =
     component.supplemental_attributes_container
 get_supplemental_attributes_container(component::AdditionalTestComponent) =
@@ -69,6 +72,7 @@ function deserialize(::Type{TestComponent}, data::Dict)
     return TestComponent(
         data["name"],
         data["val"],
+        data["val2"],
         deserialize(TimeSeriesContainer, data["time_series_container"]),
         data["supplemental_attributes_container"],
         deserialize(InfrastructureSystemsInternal, data["internal"]),


### PR DESCRIPTION
This PR adds new time series data constructors that enable time series instances with different names to share the same data. The targeted use case is one where a generator wants to use the same time series data for the fields active_power and reactive_power.