### PR TITLE
Fix `compare_values` for arrays with `NaN`, add deserialization for more union types

### DIFF
--- a/src/hdf5_time_series_storage.jl
+++ b/src/hdf5_time_series_storage.jl
@@ -799,7 +799,7 @@ function compare_values(
             @error "UUIDs don't match" uuid_x uuid_y
             return false
         end
-        if data_x != data_y
+        if !isequal(data_x, data_y)
             @error "data doesn't match" data_x data_y
             return false
         end

--- a/test/test_serialization.jl
+++ b/test/test_serialization.jl
@@ -48,6 +48,18 @@ function validate_serialization(sys::IS.SystemData; time_series_read_only = fals
     end
 end
 
+@testset "Test deserialization type matching" begin
+    nt_data = Dict("max" => 1.1, "min" => 0.9)
+    nt_type = @NamedTuple{min::Float64, max::Float64}
+    nt_result = (min = 0.9, max = 1.1)
+    @test IS.deserialize(Union{Float64, nt_type}, nt_data) == nt_result
+    @test IS.deserialize(Union{Float64, nt_type}, 4.0) == 4.0
+    @test IS.deserialize(Union{Nothing, nt_type}, nt_data) == nt_result
+    @test IS.deserialize(Union{Nothing, nt_type}, nothing) === nothing
+    @test IS.deserialize(Union{Float64, Dict}, nt_data) == nt_data
+    @test_throws ArgumentError IS.deserialize(Union{nt_type, Dict}, nt_data)
+end
+
 @testset "Test JSON serialization of system data" begin
     for in_memory in (true, false)
         sys = create_system_data_shared_time_series(; time_series_in_memory = in_memory)


### PR DESCRIPTION
This solves two issues:

1. Now that `PiecewiseStepData` HDF-serializes to an array that includes `NaN`, we need to allow `NaN` to be equal to itself when checking whether two things are the same — this is accomplished by changing `==` to `isequal`.
2. The new PowerSystems `ThermalGenerationCost` has a field of type `Union{StartUpStages, Float64}`, where `StartUpStages` is a `NamedTuple`. We didn't have code to deserialize that, but we did have code to deserialize `Union{NamedTuple, Nothing}`, so I generalized it.

I would have liked to have done most of the logic involved in (2) using the type system, but I did not seem to be able to do so without angering `detect_unbound_args`. For instance, this method solves the problem (though less generally) but is said to have unbound type parameters:
```julia
deserialize(::Type{Union{A, B}}, data::Dict) where {A <: _NOT_FROM_DICT, B <: NamedTuple} = deserialize(B, data)
```
I'm not sure I believe `detect_unbound_args` that there are unbound type parameters here, but I have opted for a more manual, less elegant, possibly more flexible approach.