### PR TITLE
Fix handling of deepcopy for SQLite databases

### DIFF
--- a/src/supplemental_attribute_manager.jl
+++ b/src/supplemental_attribute_manager.jl
@@ -3,27 +3,15 @@ const SupplementalAttributesByType =
 
 struct SupplementalAttributeManager <: InfrastructureSystemsContainer
     data::SupplementalAttributesByType
-    time_series_manager::TimeSeriesManager
     associations::SupplementalAttributeAssociations
 end
 
-function SupplementalAttributeManager(
-    data::SupplementalAttributesByType,
-    time_series_manager::TimeSeriesManager,
-)
-    return SupplementalAttributeManager(
-        data,
-        time_series_manager,
-        SupplementalAttributeAssociations(get_database(time_series_manager), true),
-    )
+function SupplementalAttributeManager(data::SupplementalAttributesByType)
+    return SupplementalAttributeManager(data, SupplementalAttributeAssociations())
 end
 
-function SupplementalAttributeManager(time_series_manager::TimeSeriesManager)
-    return SupplementalAttributeManager(
-        SupplementalAttributesByType(),
-        time_series_manager,
-        SupplementalAttributeAssociations(get_database(time_series_manager), true),
-    )
+function SupplementalAttributeManager()
+    return SupplementalAttributeManager(SupplementalAttributesByType())
 end
 
 get_member_string(::SupplementalAttributeManager) = "supplemental attributes"
@@ -70,13 +58,6 @@ function _attach_attribute!(
     if !haskey(mgr.data, T)
         mgr.data[T] = Dict{Base.UUID, T}()
     end
-    set_shared_system_references!(
-        attribute,
-        SharedSystemReferences(;
-            supplemental_attribute_manager = mgr,
-            time_series_manager = mgr.time_series_manager,
-        ),
-    )
     mgr.data[T][get_uuid(attribute)] = attribute
 end
 
@@ -263,11 +244,7 @@ function deserialize(
         @debug "Deserialized $(summary(attr))" _group = LOG_GROUP_SERIALIZATION
     end
 
-    mgr = SupplementalAttributeManager(
-        SupplementalAttributesByType(attributes),
-        time_series_manager,
-    )
-
+    mgr = SupplementalAttributeManager(SupplementalAttributesByType(attributes))
     load_records!(mgr.associations, data["associations"])
     return mgr
 end

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -62,7 +62,7 @@ function SystemData(;
         compression = compression,
     )
     components = Components(time_series_mgr, validation_descriptors)
-    supplemental_attribute_mgr = SupplementalAttributeManager(time_series_mgr)
+    supplemental_attribute_mgr = SupplementalAttributeManager()
     masked_components = Components(time_series_mgr, validation_descriptors)
     return SystemData(
         components,
@@ -934,6 +934,13 @@ function add_supplemental_attribute!(data::SystemData, component, attribute; kwa
         component,
         attribute;
         kwargs...,
+    )
+    set_shared_system_references!(
+        attribute,
+        SharedSystemReferences(;
+            supplemental_attribute_manager = data.supplemental_attribute_manager,
+            time_series_manager = data.time_series_manager,
+        ),
     )
     return
 end

--- a/src/time_series_manager.jl
+++ b/src/time_series_manager.jl
@@ -30,8 +30,6 @@ function TimeSeriesManager(;
     return TimeSeriesManager(data_store, metadata_store, read_only)
 end
 
-get_database(mgr::TimeSeriesManager) = mgr.metadata_store.db
-
 function add_time_series!(
     mgr::TimeSeriesManager,
     owner::TimeSeriesOwners,
@@ -93,24 +91,6 @@ end
 has_time_series(mgr::TimeSeriesManager, component::TimeSeriesOwners) =
     has_time_series(mgr.metadata_store, component)
 has_time_series(::Nothing, component::TimeSeriesOwners) = false
-
-function Base.deepcopy_internal(mgr::TimeSeriesManager, dict::IdDict)
-    if haskey(dict, mgr)
-        return dict[mgr]
-    end
-    data_store = deepcopy(mgr.data_store)
-    if mgr.data_store isa Hdf5TimeSeriesStorage
-        copy_to_new_file!(data_store, dirname(mgr.data_store.file_path))
-    end
-
-    new_db_file = backup_to_temp(mgr.metadata_store)
-    metadata_store = TimeSeriesMetadataStore(new_db_file)
-    new_mgr = TimeSeriesManager(data_store, metadata_store, mgr.read_only)
-    dict[mgr] = new_mgr
-    dict[mgr.data_store] = new_mgr.data_store
-    dict[mgr.metadata_store] = new_mgr.metadata_store
-    return new_mgr
-end
 
 get_metadata(
     mgr::TimeSeriesManager,

--- a/src/time_series_metadata_store.jl
+++ b/src/time_series_metadata_store.jl
@@ -3,6 +3,7 @@ const DB_FILENAME = "time_series_metadata.db"
 
 mutable struct TimeSeriesMetadataStore
     db::SQLite.DB
+    # If you add any fields, ensure they are managed in deepcopy_internal below.
 end
 
 """
@@ -99,6 +100,18 @@ function _create_indexes!(store::TimeSeriesMetadataStore)
         unique = false,
     )
     return
+end
+
+function Base.deepcopy_internal(store::TimeSeriesMetadataStore, dict::IdDict)
+    if haskey(dict, store)
+        return dict[store]
+    end
+
+    new_db = SQLite.DB()
+    backup(new_db, store.db)
+    new_store = TimeSeriesMetadataStore(new_db)
+    dict[store] = new_store
+    return new_store
 end
 
 """

--- a/src/utils/sqlite.jl
+++ b/src/utils/sqlite.jl
@@ -39,11 +39,16 @@ function backup(
 end
 
 """
-Wrapper around SQLite.DBInterface.execute to provide debug log messages.
+Wrapper around SQLite.DBInterface.execute to provide log messages.
 """
 function execute(db::SQLite.DB, query::AbstractString, log_group::Symbol)
     @debug "Execute SQL" _group = log_group query
-    return SQLite.DBInterface.execute(db, query)
+    try
+        return SQLite.DBInterface.execute(db, query)
+    catch
+        @error "Failed to send SQL query" query
+        rethrow()
+    end
 end
 
 """

--- a/test/test_supplemental_attributes.jl
+++ b/test/test_supplemental_attributes.jl
@@ -1,5 +1,5 @@
 @testset "Test add_supplemental_attribute" begin
-    mgr = IS.SupplementalAttributeManager(IS.TimeSeriesManager(; in_memory = true))
+    mgr = IS.SupplementalAttributeManager()
     geo_supplemental_attribute = IS.GeographicInfo()
     component = IS.TestComponent("component1", 5)
     IS.add_supplemental_attribute!(mgr, component, geo_supplemental_attribute)
@@ -32,7 +32,7 @@ end
 end
 
 @testset "Test remove_supplemental_attribute" begin
-    mgr = IS.SupplementalAttributeManager(IS.TimeSeriesManager(; in_memory = true))
+    mgr = IS.SupplementalAttributeManager()
     geo_supplemental_attribute = IS.GeographicInfo()
     component = IS.TestComponent("component1", 5)
     IS.add_supplemental_attribute!(mgr, component, geo_supplemental_attribute)
@@ -72,7 +72,7 @@ end
 end
 
 @testset "Test iterate_SupplementalAttributeManager" begin
-    mgr = IS.SupplementalAttributeManager(IS.TimeSeriesManager(; in_memory = true))
+    mgr = IS.SupplementalAttributeManager()
     geo_supplemental_attribute = IS.GeographicInfo()
     component = IS.TestComponent("component1", 5)
     IS.add_supplemental_attribute!(mgr, component, geo_supplemental_attribute)
@@ -80,7 +80,7 @@ end
 end
 
 @testset "Summarize SupplementalAttributeManager" begin
-    mgr = IS.SupplementalAttributeManager(IS.TimeSeriesManager(; in_memory = true))
+    mgr = IS.SupplementalAttributeManager()
     geo_supplemental_attribute = IS.GeographicInfo()
     component = IS.TestComponent("component1", 5)
     IS.add_supplemental_attribute!(mgr, component, geo_supplemental_attribute)

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -2242,10 +2242,9 @@ end
     @test_throws IS.ConflictingInputsError IS.add_time_series!(sys, component, forecast)
 end
 
-@testset "Test copy_to_new_file! on HDF5" begin
+@testset "Test deepcopy on HDF5" begin
     sys = IS.SystemData(; time_series_in_memory = false)
     name = "Component1"
-    name = "val"
     component = IS.TestComponent(name, 5)
     IS.add_component!(sys, component)
 
@@ -2260,11 +2259,13 @@ end
     @test data_input == first(values((fdata)))
 
     IS.add_time_series!(sys, component, time_series)
+    new_sys = deepcopy(sys)
     orig_file = IS.get_file_path(sys.time_series_manager.data_store)
-    IS.copy_to_new_file!(sys.time_series_manager.data_store)
-    @test orig_file != IS.get_file_path(sys.time_series_manager.data_store)
+    new_file = IS.get_file_path(new_sys.time_series_manager.data_store)
+    @test orig_file != new_file
 
-    time_series2 = IS.get_time_series(IS.Deterministic, component, name)
+    component2 = IS.get_component(IS.TestComponent, sys, name)
+    time_series2 = IS.get_time_series(IS.Deterministic, component2, name)
     @test time_series2 isa IS.Deterministic
     fdata2 = IS.get_data(time_series2)
     @test initial_timestamp == first(keys((fdata2)))


### PR DESCRIPTION
This PR fixes a bug introduced by #357. The code did not properly handle the shared references to the internal SQLite database during a deepcopy of the system. This fix does the following:
- Use separate SQLite in-memory databases for time series metadata and supplemental attribute associations.
- Implemental `deepcopy_internal` for structs that do not support the Julia default method at the lowest possible level.

An alternate is solution is to implement management of the SQLite database at the `SystemData` level. I did not go that route because of the requirement that supplemental attributes be persisted to JSON, not SQLite, during serialization.