### PR TITLE
Accommodate `NaN` in `FunctionData` validation and comparison, extend serialization to more types

### DIFF
--- a/src/function_data.jl
+++ b/src/function_data.jl
@@ -85,7 +85,7 @@ function transform_array_for_hdf(
     return transform_array_for_hdf(transfd_data)
 end
 
-function _validate_piecewise_x(x_coords)
+function _validate_piecewise_x(x_coords::Vector)
     (length(x_coords) < 2) &&
         throw(ArgumentError("Must specify at least two x-coordinates"))
     # This could be generalized to allow NaNs in more places

--- a/src/function_data.jl
+++ b/src/function_data.jl
@@ -287,9 +287,9 @@ Base.length(pwl::Union{PiecewiseLinearData, PiecewiseStepData}) =
 Base.getindex(pwl::PiecewiseLinearData, ix::Int) =
     getindex(get_points(pwl), ix)
 
-Base.:(==)(a::T, b::T) where T <: FunctionData = double_equals_from_fields(a, b)
+Base.:(==)(a::T, b::T) where {T <: FunctionData} = double_equals_from_fields(a, b)
 
-Base.isequal(a::T, b::T) where T <: FunctionData = isequal_from_fields(a, b)
+Base.isequal(a::T, b::T) where {T <: FunctionData} = isequal_from_fields(a, b)
 
 Base.hash(a::FunctionData) = hash_from_fields(a)
 

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -209,8 +209,8 @@ function deserialize(::Type{T}, data::Dict) where {T <: NamedTuple}
     return T(key = data[string(key)] for key in fieldnames(T))
 end
 
-# Some types that definitely won't be deserialized from Dicts
-const _NOT_FROM_DICT = Union{Nothing, Real, AbstractString}
+# Some types that definitely won't be deserialized from raw Dicts
+const _NOT_FROM_DICT = Union{Nothing, Real, AbstractString, TimeSeriesKey}
 
 # If deserializing into a Union of some _NOT_FROM_DICT and something else (e.g., a
 # NamedTuple) and we are given a Dict as input data, pick the something else. NOTE: it would

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -618,7 +618,7 @@ isequal_from_fields(a::T, b::T) where {T} =
 hash_from_fields(a) = hash_from_fields(a, zero(UInt))
 
 function hash_from_fields(a, h::UInt)
-    for field in sort(collect(fieldnames(typeof(a))))
+    for field in sort!(collect(fieldnames(typeof(a))))
         h = hash(getfield(a, field), h)
     end
     return h

--- a/test/test_function_data.jl
+++ b/test/test_function_data.jl
@@ -170,9 +170,12 @@ end
     for my_type in IS.get_all_concrete_subtypes(IS.FunctionData)
         @test examples_1[(my_type, false)] == examples_2[(my_type, false)]
         @test examples_1[(my_type, true)] != examples_2[(my_type, true)]
+        @test examples_1[(my_type, false)] != examples_2[(my_type, true)]
         @test isequal(examples_1[(my_type, false)], examples_2[(my_type, false)])
         @test isequal(examples_1[(my_type, true)], examples_2[(my_type, true)])
+        @test !isequal(examples_1[(my_type, false)], examples_2[(my_type, true)])
         @test hash(examples_1[(my_type, false)]) == hash(examples_2[(my_type, false)])
         @test hash(examples_1[(my_type, true)]) == hash(examples_2[(my_type, true)])
+        @test hash(examples_1[(my_type, false)]) != hash(examples_2[(my_type, true)])
     end
 end

--- a/test/test_time_series_transformations.jl
+++ b/test/test_time_series_transformations.jl
@@ -68,6 +68,7 @@ tst_gen_piecewise_step(start, n) = [
 
 tst_test_datas_1 = [
     [1.0, 2.0, 3.0],
+    [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0), (7.0, 8.0, 9.0), (10.0, 11.0, 12.0)],
     [
         IS.LinearFunctionData(1.0),
         IS.LinearFunctionData(2.0),
@@ -90,6 +91,7 @@ tst_test_datas_1 = [
 
 tst_test_datas_2 = [
     [4.0, 5.0, 6.0],
+    [(21.0, 22.0, 23.0), (24.0, 25.0, 26.0), (27.0, 28.0, 29.0), (30.0, 31.0, 32.0)],
     [
         IS.LinearFunctionData(4.0),
         IS.LinearFunctionData(5.0),


### PR DESCRIPTION
The market bid cost curve representation relies on putting `NaN`s in `PiecewiseStepData`, so I took the opportunity to make `==`, `isequal`, and `hash` work nicely for `FunctionData` in general.