### PR TITLE
Add support for legacy JSON schema

### DIFF
--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -802,7 +802,11 @@ function deserialize(
     subsystems = Dict(k => Set(Base.UUID.(v)) for (k, v) in raw["subsystems"])
     supplemental_attribute_manager = deserialize(
         SupplementalAttributeManager,
-        raw["supplemental_attribute_manager"],
+        get(
+            raw,
+            "supplemental_attribute_manager",
+            Dict("attributes" => [], "associations" => []),
+        ),
         time_series_manager,
     )
     internal = deserialize(InfrastructureSystemsInternal, raw["internal"])


### PR DESCRIPTION
This will allow legacy system JSON files, such as the PSID system files checked into PowerSystemsTestData, to deserialize.