### PR TITLE
Regenerate structs to pass tests

### DIFF
--- a/src/generated/DeterministicMetadata.jl
+++ b/src/generated/DeterministicMetadata.jl
@@ -23,16 +23,16 @@ A deterministic forecast for a particular data field in a Component.
 
 # Arguments
 - `name::String`: user-defined name
-- `resolution::Dates.Period`
+- `resolution::Dates.Period`:
 - `initial_timestamp::Dates.DateTime`: time series availability time
 - `interval::Dates.Period`: time step between forecast windows
 - `count::Int`: number of forecast windows
 - `time_series_uuid::UUIDs.UUID`: reference to time series data
 - `horizon::Dates.Period`: length of this time series
 - `time_series_type::Type{<:AbstractDeterministic}`: Type of the time series data associated with this metadata.
-- `scaling_factor_multiplier::Union{Nothing, Function}`: Applicable when the time series data are scaling factors. Called on the associated component to convert the values.
-- `features::Dict{String, Union{Bool, Int, String}}`: User-defined tags that differentiate multiple time series arrays that represent the same component attribute, such as different arrays for different scenarios or years.
-- `internal::InfrastructureSystemsInternal`
+- `scaling_factor_multiplier::Union{Nothing, Function}`: (default: `nothing`) Applicable when the time series data are scaling factors. Called on the associated component to convert the values.
+- `features::Dict{String, Union{Bool, Int, String}}`: (default: `Dict{String, Any}()`) User-defined tags that differentiate multiple time series arrays that represent the same component attribute, such as different arrays for different scenarios or years.
+- `internal::InfrastructureSystemsInternal`:
 """
 mutable struct DeterministicMetadata <: ForecastMetadata
     "user-defined name"

--- a/src/generated/ProbabilisticMetadata.jl
+++ b/src/generated/ProbabilisticMetadata.jl
@@ -24,15 +24,15 @@ A Probabilistic forecast for a particular data field in a Component.
 # Arguments
 - `name::String`: user-defined name
 - `initial_timestamp::Dates.DateTime`: time series availability time
-- `resolution::Dates.Period`
+- `resolution::Dates.Period`:
 - `interval::Dates.Period`: time step between forecast windows
 - `count::Int`: number of forecast windows
 - `percentiles::Vector{Float64}`: Percentiles for the probabilistic forecast
 - `time_series_uuid::UUIDs.UUID`: reference to time series data
 - `horizon::Dates.Period`: length of this time series
-- `scaling_factor_multiplier::Union{Nothing, Function}`: Applicable when the time series data are scaling factors. Called on the associated component to convert the values.
-- `features::Dict{String, Union{Bool, Int, String}}`: User-defined tags that differentiate multiple time series arrays that represent the same component attribute, such as different arrays for different scenarios or years.
-- `internal::InfrastructureSystemsInternal`
+- `scaling_factor_multiplier::Union{Nothing, Function}`: (default: `nothing`) Applicable when the time series data are scaling factors. Called on the associated component to convert the values.
+- `features::Dict{String, Union{Bool, Int, String}}`: (default: `Dict{String, Any}()`) User-defined tags that differentiate multiple time series arrays that represent the same component attribute, such as different arrays for different scenarios or years.
+- `internal::InfrastructureSystemsInternal`:
 """
 mutable struct ProbabilisticMetadata <: ForecastMetadata
     "user-defined name"

--- a/src/generated/ScenariosMetadata.jl
+++ b/src/generated/ScenariosMetadata.jl
@@ -23,16 +23,16 @@ A Discrete Scenario Based time series for a particular data field in a Component
 
 # Arguments
 - `name::String`: user-defined name
-- `resolution::Dates.Period`
+- `resolution::Dates.Period`:
 - `initial_timestamp::Dates.DateTime`: time series availability time
 - `interval::Dates.Period`: time step between forecast windows
 - `scenario_count::Int64`: Number of scenarios
 - `count::Int`: number of forecast windows
 - `time_series_uuid::UUIDs.UUID`: reference to time series data
 - `horizon::Dates.Period`: length of this time series
-- `scaling_factor_multiplier::Union{Nothing, Function}`: Applicable when the time series data are scaling factors. Called on the associated component to convert the values.
-- `features::Dict{String, Union{Bool, Int, String}}`: User-defined tags that differentiate multiple time series arrays that represent the same component attribute, such as different arrays for different scenarios or years.
-- `internal::InfrastructureSystemsInternal`
+- `scaling_factor_multiplier::Union{Nothing, Function}`: (default: `nothing`) Applicable when the time series data are scaling factors. Called on the associated component to convert the values.
+- `features::Dict{String, Union{Bool, Int, String}}`: (default: `Dict{String, Any}()`) User-defined tags that differentiate multiple time series arrays that represent the same component attribute, such as different arrays for different scenarios or years.
+- `internal::InfrastructureSystemsInternal`:
 """
 mutable struct ScenariosMetadata <: ForecastMetadata
     "user-defined name"

--- a/src/generated/SingleTimeSeriesMetadata.jl
+++ b/src/generated/SingleTimeSeriesMetadata.jl
@@ -20,13 +20,13 @@ A TimeSeries Data object in contigous form.
 
 # Arguments
 - `name::String`: user-defined name
-- `resolution::Dates.Period`
+- `resolution::Dates.Period`:
 - `initial_timestamp::Dates.DateTime`: time series availability time
 - `time_series_uuid::UUIDs.UUID`: reference to time series data
 - `length::Int`: length of this time series
-- `scaling_factor_multiplier::Union{Nothing, Function}`: Applicable when the time series data are scaling factors. Called on the associated component to convert the values.
-- `features::Dict{String, Union{Bool, Int, String}}`: User-defined tags that differentiate multiple time series arrays that represent the same component attribute, such as different arrays for different scenarios or years.
-- `internal::InfrastructureSystemsInternal`
+- `scaling_factor_multiplier::Union{Nothing, Function}`: (default: `nothing`) Applicable when the time series data are scaling factors. Called on the associated component to convert the values.
+- `features::Dict{String, Union{Bool, Int, String}}`: (default: `Dict{String, Any}()`) User-defined tags that differentiate multiple time series arrays that represent the same component attribute, such as different arrays for different scenarios or years.
+- `internal::InfrastructureSystemsInternal`:
 """
 mutable struct SingleTimeSeriesMetadata <: StaticTimeSeriesMetadata
     "user-defined name"


### PR DESCRIPTION
https://github.com/NREL-Sienna/InfrastructureSystems.jl/pull/374 changed the template format, [causing](https://github.com/NREL-Sienna/InfrastructureSystems.jl/pull/374/checks) these sorts of errors:
```
┌ Error: Generated structs do not match descriptor file
│   file1 = "DeterministicMetadata.jl"
│   line1 = "- `resolution::Dates.Period`:"
│   line2 = "- `resolution::Dates.Period`"
└ @ .../InfrastructureSystems.jl/src/utils/generate_structs.jl:268
```
This just regenerates the structs to fix the errors. I do note that the format implied by https://github.com/NREL-Sienna/InfrastructureSystems.jl/pull/374 is a little strange for fields without descriptions, like `resolution`; maybe that should be changed?