### PR TITLE
Add `FunctionData` Printing

### DIFF
--- a/src/function_data.jl
+++ b/src/function_data.jl
@@ -41,6 +41,12 @@ function transform_array_for_hdf(
     return transform_array_for_hdf(transfd_data)
 end
 
+Base.show(io::IO, ::MIME"text/plain", fd::LinearFunctionData) =
+    print(
+        io,
+        "$(typeof(fd)) representing function f(x) = $(fd.proportional_term) x + $(fd.constant_term)",
+    )
+
 """
 Structure to represent the underlying data of quadratic functions. Principally used for the
 representation of cost functions
@@ -93,6 +99,12 @@ function _validate_piecewise_x(x_coords::Vector)
         throw(ArgumentError("Piecewise x-coordinates must be ascending, got $x_coords"))
     end
 end
+
+Base.show(io::IO, ::MIME"text/plain", fd::QuadraticFunctionData) =
+    print(
+        io,
+        "$(typeof(fd)) representing function f(x) = $(fd.quadratic_term) x^2 + $(fd.proportional_term) x + $(fd.constant_term)",
+    )
 
 """
 Structure to represent piecewise linear data as a series of points: two points define one
@@ -191,6 +203,16 @@ function transform_array_for_hdf(
     return transform_array_for_hdf(transfd_data)
 end
 
+function Base.show(io::IO, ::MIME"text/plain", fd::PiecewiseLinearData)
+    print(
+        io,
+        "$(typeof(fd)) representing piecewise linear function y = f(x) connecting points:",
+    )
+    for point in fd.points
+        print(io, "\n  $point")
+    end
+end
+
 """
 Structure to represent a step function as a series of endpoint x-coordinates and segment
 y-coordinates: two x-coordinates and one y-coordinate defines a single segment, three
@@ -272,6 +294,13 @@ function transform_array_for_hdf(
         transfd_data[k] = _transform_pwl_step_vector_hdf(fd)
     end
     return transform_array_for_hdf(transfd_data)
+end
+
+function Base.show(io::IO, ::MIME"text/plain", fd::PiecewiseStepData)
+    print(io, "$(typeof(fd)) representing step (piecewise constant) function f(x) =")
+    for (y, x1, x2) in zip(fd.y_coords, fd.x_coords[1:(end - 1)], fd.x_coords[2:end])
+        print(io, "\n  $y for x in [$x1, $x2)")
+    end
 end
 
 """

--- a/src/function_data.jl
+++ b/src/function_data.jl
@@ -41,11 +41,10 @@ function transform_array_for_hdf(
     return transform_array_for_hdf(transfd_data)
 end
 
-Base.show(io::IO, ::MIME"text/plain", fd::LinearFunctionData) =
-    print(
-        io,
-        "$(typeof(fd)) representing function f(x) = $(fd.proportional_term) x + $(fd.constant_term)",
-    )
+function Base.show(io::IO, ::MIME"text/plain", fd::LinearFunctionData)
+    get(io, :compact, false)::Bool || print(io, "$(typeof(fd)) representing function ")
+    print(io, "f(x) = $(fd.proportional_term) x + $(fd.constant_term)")
+end
 
 """
 Structure to represent the underlying data of quadratic functions. Principally used for the
@@ -100,11 +99,13 @@ function _validate_piecewise_x(x_coords::Vector)
     end
 end
 
-Base.show(io::IO, ::MIME"text/plain", fd::QuadraticFunctionData) =
+function Base.show(io::IO, ::MIME"text/plain", fd::QuadraticFunctionData)
+    get(io, :compact, false)::Bool || print(io, "$(typeof(fd)) representing function ")
     print(
         io,
-        "$(typeof(fd)) representing function f(x) = $(fd.quadratic_term) x^2 + $(fd.proportional_term) x + $(fd.constant_term)",
+        "f(x) = $(fd.quadratic_term) x^2 + $(fd.proportional_term) x + $(fd.constant_term)",
     )
+end
 
 """
 Structure to represent piecewise linear data as a series of points: two points define one
@@ -204,10 +205,12 @@ function transform_array_for_hdf(
 end
 
 function Base.show(io::IO, ::MIME"text/plain", fd::PiecewiseLinearData)
-    print(
-        io,
-        "$(typeof(fd)) representing piecewise linear function y = f(x) connecting points:",
-    )
+    if get(io, :compact, false)::Bool
+        print(io, "piecewise linear ")
+    else
+        print(io, "$(typeof(fd)) representing piecewise linear function ")
+    end
+    print(io, "y = f(x) connecting points:")
     for point in fd.points
         print(io, "\n  $point")
     end
@@ -297,7 +300,9 @@ function transform_array_for_hdf(
 end
 
 function Base.show(io::IO, ::MIME"text/plain", fd::PiecewiseStepData)
-    print(io, "$(typeof(fd)) representing step (piecewise constant) function f(x) =")
+    get(io, :compact, false)::Bool ||
+        print(io, "$(typeof(fd)) representing step (piecewise constant) function ")
+    print(io, "f(x) =")
     for (y, x1, x2) in zip(fd.y_coords, fd.x_coords[1:(end - 1)], fd.x_coords[2:end])
         print(io, "\n  $y for x in [$x1, $x2)")
     end

--- a/test/test_function_data.jl
+++ b/test/test_function_data.jl
@@ -193,14 +193,19 @@ end
         "InfrastructureSystems.PiecewiseLinearData representing piecewise linear function y = f(x) connecting points:\n  (x = 1.0, y = 1.0)\n  (x = 3.0, y = 5.0)\n  (x = 5.0, y = 10.0)",
         "InfrastructureSystems.PiecewiseStepData representing step (piecewise constant) function f(x) =\n  2.0 for x in [1.0, 3.0)\n  2.5 for x in [3.0, 5.0)",
     ]
+    compact_plain_answers = [
+        "f(x) = 5.0 x + 1.0",
+        "f(x) = 2.0 x^2 + 3.0 x + 4.0",
+        "piecewise linear y = f(x) connecting points:\n  (x = 1.0, y = 1.0)\n  (x = 3.0, y = 5.0)\n  (x = 5.0, y = 10.0)",
+        "f(x) =\n  2.0 for x in [1.0, 3.0)\n  2.5 for x in [3.0, 5.0)",
+    ]
 
-    io = IOBuffer()
-    for (fd, repr_ans, plain_ans) in
-        zip(get_test_function_data(), repr_answers, plain_answers)
-        @test repr(fd) == repr_ans
-        show(io, fd)
-        @test String(take!(io)) == repr_ans
-        show(io, "text/plain", fd)
-        @test String(take!(io)) == plain_ans
+    for (fd, repr_ans, plain_ans, compact_plain_ans) in
+        zip(get_test_function_data(), repr_answers, plain_answers, compact_plain_answers)
+        @test sprint(show, fd) == repr(fd) == repr_ans
+        @test sprint(show, "text/plain", fd) ==
+              sprint(show, "text/plain", fd; context = :compact => false) == plain_ans
+        @test sprint(show, "text/plain", fd; context = :compact => true) ==
+              compact_plain_ans
     end
 end

--- a/test/test_function_data.jl
+++ b/test/test_function_data.jl
@@ -160,7 +160,7 @@ end
     end
 end
 
-@testset "Test equality with NaN" begin
+@testset "Test FunctionData equality with NaN" begin
     examples_1 = get_more_test_function_data()
     examples_2 = get_more_test_function_data()
 
@@ -177,5 +177,30 @@ end
         @test hash(examples_1[(my_type, false)]) == hash(examples_2[(my_type, false)])
         @test hash(examples_1[(my_type, true)]) == hash(examples_2[(my_type, true)])
         @test hash(examples_1[(my_type, false)]) != hash(examples_2[(my_type, true)])
+    end
+end
+
+@testset "Test FunctionData printing" begin
+    repr_answers = [
+        "InfrastructureSystems.LinearFunctionData(5.0, 1.0)",
+        "InfrastructureSystems.QuadraticFunctionData(2.0, 3.0, 4.0)",
+        "InfrastructureSystems.PiecewiseLinearData(@NamedTuple{x::Float64, y::Float64}[(x = 1.0, y = 1.0), (x = 3.0, y = 5.0), (x = 5.0, y = 10.0)])",
+        "InfrastructureSystems.PiecewiseStepData([1.0, 3.0, 5.0], [2.0, 2.5])",
+    ]
+    plain_answers = [
+        "InfrastructureSystems.LinearFunctionData representing function f(x) = 5.0 x + 1.0",
+        "InfrastructureSystems.QuadraticFunctionData representing function f(x) = 2.0 x^2 + 3.0 x + 4.0",
+        "InfrastructureSystems.PiecewiseLinearData representing piecewise linear function y = f(x) connecting points:\n  (x = 1.0, y = 1.0)\n  (x = 3.0, y = 5.0)\n  (x = 5.0, y = 10.0)",
+        "InfrastructureSystems.PiecewiseStepData representing step (piecewise constant) function f(x) =\n  2.0 for x in [1.0, 3.0)\n  2.5 for x in [3.0, 5.0)",
+    ]
+
+    io = IOBuffer()
+    for (fd, repr_ans, plain_ans) in
+        zip(get_test_function_data(), repr_answers, plain_answers)
+        @test repr(fd) == repr_ans
+        show(io, fd)
+        @test String(take!(io)) == repr_ans
+        show(io, "text/plain", fd)
+        @test String(take!(io)) == plain_ans
     end
 end

--- a/test/test_printing.jl
+++ b/test/test_printing.jl
@@ -6,7 +6,7 @@
     )
     io = IOBuffer()
     for mime in ("text/plain", "text/html")
-        show(io, "text/plain", sys)
+        show(io, mime, sys)
         text = String(take!(io))
         @test occursin("TestComponent", text)
         @test occursin("time_series_type", text)


### PR DESCRIPTION
I implemented some more human-friendly printing of the various `FunctionData`:
<img width="1186" alt="Screenshot 2024-06-11 at 4 04 51 PM" src="https://github.com/NREL-Sienna/InfrastructureSystems.jl/assets/23368820/66e075d4-9a2f-4965-9286-ec55637929e9">

These could be useful when I do the same thing for the PSY cost structs (https://github.com/NREL-Sienna/PowerSystems.jl/issues/1048).

Also fixed a typo in existing printing test code.