### PR TITLE
Add option to specify equality predicate for `compare_values` and provide a more sensible default (IS)

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -40,3 +40,7 @@ Base.showerror(io::IO, e::NotImplementedError) =
 const CONSTANT = Float64
 const LIM_TOL = 1e-6
 const XY_COORDS = @NamedTuple{x::Float64, y::Float64}
+
+# See https://github.com/JuliaLang/julia/issues/18485
+"An equality predicate that is `true` for `NaN, NaN` (unlike `==`) and for `-0.0, 0.0` (unlike `isequal`)"
+isequivalent(x, y) = isequal(x, y) || (x == y)

--- a/src/components.jl
+++ b/src/components.jl
@@ -387,11 +387,11 @@ function set_name!(
 end
 
 function compare_values(
+    match_fn::Union{Function, Nothing},
     x::Components,
     y::Components;
     compare_uuids = false,
     exclude = Set{Symbol}(),
-    match_fn = isequivalent,
 )
     match = true
     for name in fieldnames(Components)
@@ -401,11 +401,11 @@ function compare_values(
         val_x = getproperty(x, name)
         val_y = getproperty(y, name)
         if !compare_values(
+            match_fn,
             val_x,
             val_y;
             compare_uuids = compare_uuids,
             exclude = exclude,
-            match_fn = match_fn,
         )
             val_x = getproperty(x, name)
             val_y = getproperty(y, name)

--- a/src/components.jl
+++ b/src/components.jl
@@ -391,6 +391,7 @@ function compare_values(
     y::Components;
     compare_uuids = false,
     exclude = Set{Symbol}(),
+    match_fn = isequivalent,
 )
     match = true
     for name in fieldnames(Components)
@@ -399,7 +400,13 @@ function compare_values(
         name == :time_series_manager && continue
         val_x = getproperty(x, name)
         val_y = getproperty(y, name)
-        if !compare_values(val_x, val_y; compare_uuids = compare_uuids, exclude = exclude)
+        if !compare_values(
+            val_x,
+            val_y;
+            compare_uuids = compare_uuids,
+            exclude = exclude,
+            match_fn = match_fn,
+        )
             val_x = getproperty(x, name)
             val_y = getproperty(y, name)
             @error "Components field = $name does not match" val_x val_y

--- a/src/hdf5_time_series_storage.jl
+++ b/src/hdf5_time_series_storage.jl
@@ -805,6 +805,7 @@ function compare_values(
     x::Hdf5TimeSeriesStorage,
     y::Hdf5TimeSeriesStorage;
     compare_uuids = false,
+    match_fn = isequivalent,
     kwargs...,
 )
     item_x = sort!(collect(iterate_time_series(x)); by = z -> z[1])
@@ -825,7 +826,7 @@ function compare_values(
             @error "UUIDs don't match" uuid_x uuid_y
             return false
         end
-        if !isequal(data_x, data_y)
+        if !match_fn(data_x, data_y)
             @error "data doesn't match" data_x data_y
             return false
         end

--- a/src/hdf5_time_series_storage.jl
+++ b/src/hdf5_time_series_storage.jl
@@ -802,10 +802,10 @@ function _get_time_series_path(root::HDF5.Group, uuid::UUIDs.UUID)
 end
 
 function compare_values(
+    match_fn::Union{Function, Nothing},
     x::Hdf5TimeSeriesStorage,
     y::Hdf5TimeSeriesStorage;
     compare_uuids = false,
-    match_fn = isequivalent,
     kwargs...,
 )
     item_x = sort!(collect(iterate_time_series(x)); by = z -> z[1])
@@ -815,6 +815,7 @@ function compare_values(
         return false
     end
 
+    match_fn = _fetch_match_fn(match_fn)
     if !compare_uuids
         # TODO: This could be improved. But we still get plenty of verification when
         # UUIDs are not changed.

--- a/src/in_memory_time_series_storage.jl
+++ b/src/in_memory_time_series_storage.jl
@@ -156,10 +156,10 @@ function convert_to_hdf5(storage::InMemoryTimeSeriesStorage, filename::AbstractS
 end
 
 function compare_values(
+    match_fn::Union{Function, Nothing},
     x::InMemoryTimeSeriesStorage,
     y::InMemoryTimeSeriesStorage;
     compare_uuids = false,
-    match_fn = isequivalent,
     kwargs...,
 )
     keys_x = sort!(collect(keys(x.data)))
@@ -169,6 +169,7 @@ function compare_values(
         return false
     end
 
+    match_fn = _fetch_match_fn(match_fn)
     for key in keys_x
         ts_x = x.data[key]
         ts_y = y.data[key]

--- a/src/in_memory_time_series_storage.jl
+++ b/src/in_memory_time_series_storage.jl
@@ -159,6 +159,7 @@ function compare_values(
     x::InMemoryTimeSeriesStorage,
     y::InMemoryTimeSeriesStorage;
     compare_uuids = false,
+    match_fn = isequivalent,
     kwargs...,
 )
     keys_x = sort!(collect(keys(x.data)))
@@ -175,7 +176,7 @@ function compare_values(
             @error "timestamps don't match" ts_x ts_y
             return false
         end
-        if TimeSeries.values(get_data(ts_x)) != TimeSeries.values(get_data(ts_y))
+        if !match_fn(TimeSeries.values(get_data(ts_x)), TimeSeries.values(get_data(ts_y)))
             @error "values don't match" ts_x ts_y
             return false
         end

--- a/src/internal.jl
+++ b/src/internal.jl
@@ -126,6 +126,7 @@ function compare_values(
     y::InfrastructureSystemsInternal;
     compare_uuids = false,
     exclude = Set{Symbol}(),
+    match_fn = isequivalent,
 )
     match = true
     for name in fieldnames(InfrastructureSystemsInternal)
@@ -146,7 +147,13 @@ function compare_values(
                collect(keys(val2)) == [SERIALIZATION_METADATA_KEY]
                 continue
             end
-            if !compare_values(val1, val2; compare_uuids = compare_uuids, exclude = exclude)
+            if !compare_values(
+                val1,
+                val2;
+                compare_uuids = compare_uuids,
+                exclude = exclude,
+                match_fn = match_fn,
+            )
                 @error "ext does not match" val1 val2
                 match = false
             end
@@ -155,6 +162,7 @@ function compare_values(
             getproperty(y, name);
             compare_uuids = compare_uuids,
             exclude = exclude,
+            match_fn = match_fn,
         )
             @error "InfrastructureSystemsInternal field=$name does not match"
             match = false

--- a/src/internal.jl
+++ b/src/internal.jl
@@ -122,11 +122,11 @@ function serialize(internal::InfrastructureSystemsInternal)
 end
 
 function compare_values(
+    match_fn::Union{Function, Nothing},
     x::InfrastructureSystemsInternal,
     y::InfrastructureSystemsInternal;
     compare_uuids = false,
     exclude = Set{Symbol}(),
-    match_fn = isequivalent,
 )
     match = true
     for name in fieldnames(InfrastructureSystemsInternal)
@@ -148,21 +148,21 @@ function compare_values(
                 continue
             end
             if !compare_values(
+                match_fn,
                 val1,
                 val2;
                 compare_uuids = compare_uuids,
                 exclude = exclude,
-                match_fn = match_fn,
             )
                 @error "ext does not match" val1 val2
                 match = false
             end
         elseif !compare_values(
+            match_fn,
             getproperty(x, name),
             getproperty(y, name);
             compare_uuids = compare_uuids,
             exclude = exclude,
-            match_fn = match_fn,
         )
             @error "InfrastructureSystemsInternal field=$name does not match"
             match = false

--- a/src/supplemental_attribute_associations.jl
+++ b/src/supplemental_attribute_associations.jl
@@ -406,6 +406,7 @@ function compare_values(
     y::SupplementalAttributeAssociations;
     compare_uuids = false,
     exclude = Set{Symbol}(),
+    match_fn = isequivalent,
 )
     !compare_uuids && return true
     query = """
@@ -415,7 +416,7 @@ function compare_values(
     """
     table_x = Tables.rowtable(_execute(x, query))
     table_y = Tables.rowtable(_execute(y, query))
-    return table_x == table_y
+    return match_fn(table_x, table_y)
 end
 
 _execute(s::SupplementalAttributeAssociations, q, p = nothing) =

--- a/src/supplemental_attribute_associations.jl
+++ b/src/supplemental_attribute_associations.jl
@@ -402,11 +402,11 @@ function _remove_associations!(
 end
 
 function compare_values(
+    match_fn::Union{Function, Nothing},
     x::SupplementalAttributeAssociations,
     y::SupplementalAttributeAssociations;
     compare_uuids = false,
     exclude = Set{Symbol}(),
-    match_fn = isequivalent,
 )
     !compare_uuids && return true
     query = """
@@ -416,6 +416,7 @@ function compare_values(
     """
     table_x = Tables.rowtable(_execute(x, query))
     table_y = Tables.rowtable(_execute(y, query))
+    match_fn = _fetch_match_fn(match_fn)
     return match_fn(table_x, table_y)
 end
 

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -338,11 +338,11 @@ function _validate(data::SystemData, attribute::SupplementalAttribute)
 end
 
 function compare_values(
+    match_fn::Union{Function, Nothing},
     x::SystemData,
     y::SystemData;
     compare_uuids = false,
     exclude = Set{Symbol}(),
-    match_fn = isequivalent,
 )
     match = true
     for name in fieldnames(SystemData)
@@ -355,11 +355,11 @@ function compare_values(
         val_x = getproperty(x, name)
         val_y = getproperty(y, name)
         if !compare_values(
+            match_fn,
             val_x,
             val_y;
             compare_uuids = compare_uuids,
             exclude = exclude,
-            match_fn = match_fn,
         )
             @error "SystemData field = $name does not match" getproperty(x, name) getproperty(
                 y,

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -342,6 +342,7 @@ function compare_values(
     y::SystemData;
     compare_uuids = false,
     exclude = Set{Symbol}(),
+    match_fn = isequivalent,
 )
     match = true
     for name in fieldnames(SystemData)
@@ -353,7 +354,13 @@ function compare_values(
         end
         val_x = getproperty(x, name)
         val_y = getproperty(y, name)
-        if !compare_values(val_x, val_y; compare_uuids = compare_uuids, exclude = exclude)
+        if !compare_values(
+            val_x,
+            val_y;
+            compare_uuids = compare_uuids,
+            exclude = exclude,
+            match_fn = match_fn,
+        )
             @error "SystemData field = $name does not match" getproperty(x, name) getproperty(
                 y,
                 name,

--- a/src/time_series_manager.jl
+++ b/src/time_series_manager.jl
@@ -246,6 +246,7 @@ function compare_values(
     y::TimeSeriesManager;
     compare_uuids = false,
     exclude = Set{Symbol}(),
+    match_fn = isequivalent,
 )
     match = true
     for name in fieldnames(TimeSeriesManager)
@@ -262,7 +263,13 @@ function compare_values(
             continue
         end
 
-        if !compare_values(val_x, val_y; compare_uuids = compare_uuids, exclude = exclude)
+        if !compare_values(
+            val_x,
+            val_y;
+            compare_uuids = compare_uuids,
+            exclude = exclude,
+            match_fn = match_fn,
+        )
             @error "TimeSeriesManager field = $name does not match" getproperty(x, name) getproperty(
                 y,
                 name,

--- a/src/time_series_manager.jl
+++ b/src/time_series_manager.jl
@@ -242,11 +242,11 @@ function _throw_if_read_only(mgr::TimeSeriesManager)
 end
 
 function compare_values(
+    match_fn::Union{Function, Nothing},
     x::TimeSeriesManager,
     y::TimeSeriesManager;
     compare_uuids = false,
     exclude = Set{Symbol}(),
-    match_fn = isequivalent,
 )
     match = true
     for name in fieldnames(TimeSeriesManager)
@@ -264,11 +264,11 @@ function compare_values(
         end
 
         if !compare_values(
+            match_fn,
             val_x,
             val_y;
             compare_uuids = compare_uuids,
             exclude = exclude,
-            match_fn = match_fn,
         )
             @error "TimeSeriesManager field = $name does not match" getproperty(x, name) getproperty(
                 y,

--- a/src/time_series_metadata_store.jl
+++ b/src/time_series_metadata_store.jl
@@ -1044,6 +1044,7 @@ function compare_values(
     y::TimeSeriesMetadataStore;
     compare_uuids = false,
     exclude = Set{Symbol}(),
+    match_fn = isequivalent,
 )
     # Note that we can't compare missing values.
     owner_uuid = compare_uuids ? ", owner_uuid" : ""
@@ -1053,7 +1054,7 @@ function compare_values(
     """
     table_x = Tables.rowtable(_execute(x, query))
     table_y = Tables.rowtable(_execute(y, query))
-    return table_x == table_y
+    return match_fn(table_x, table_y)
 end
 
 ### Non-TimeSeriesMetadataStore functions ###

--- a/src/time_series_metadata_store.jl
+++ b/src/time_series_metadata_store.jl
@@ -1040,11 +1040,11 @@ function _try_time_series_metadata_by_full_params(
 end
 
 function compare_values(
+    match_fn::Union{Function, Nothing},
     x::TimeSeriesMetadataStore,
     y::TimeSeriesMetadataStore;
     compare_uuids = false,
     exclude = Set{Symbol}(),
-    match_fn = isequivalent,
 )
     # Note that we can't compare missing values.
     owner_uuid = compare_uuids ? ", owner_uuid" : ""
@@ -1054,6 +1054,7 @@ function compare_values(
     """
     table_x = Tables.rowtable(_execute(x, query))
     table_y = Tables.rowtable(_execute(y, query))
+    match_fn = _fetch_match_fn(match_fn)
     return match_fn(table_x, table_y)
 end
 

--- a/test/test_system_data.jl
+++ b/test/test_system_data.jl
@@ -159,6 +159,27 @@ end
         IS.get_component(IS.TestComponent, data1, "a"),
         IS.get_component(IS.TestComponent, data2, "a"),
     )
+
+    # Test match_fn
+    @test IS.compare_values(NaN, NaN)  # True by default because the default match_fn is now `IS.isequivalent`
+    @test IS.compare_values(0.0, -0.0)
+    @test IS.compare_values(0, -0.0)
+    @test !IS.compare_values(0.0, -0.0; match_fn = isequal)
+    @test !IS.compare_values(NaN, NaN; match_fn = ==)
+    @test !IS.compare_values(1.0, 1.0 + 1e-8)
+    @test IS.compare_values(1.0, 1.0 + 1e-8; match_fn = isapprox)
+
+    my_match_fn(a::String, b::String) = (a == b)
+    my_match_fn(a::Float64, b::Float64) = isapprox(a, b; atol = 0.1)
+    IS.compare_values(["a", 1.0], ["a", 1.05]; match_fn = my_match_fn)
+
+    my_match_fn_2(a::Int64, b::Int64) = isapprox(a, b; rtol = 0.1)
+    my_match_fn_2(a, b) = isequal(a, b)
+    data3 = IS.SystemData()
+    IS.add_component!(data3, IS.TestComponent("a", 100))
+    data4 = IS.SystemData()
+    IS.add_component!(data4, IS.TestComponent("a", 105))
+    @test IS.compare_values(data3, data4; match_fn = my_match_fn_2)
 end
 
 @testset "Test compression settings" begin

--- a/test/test_system_data.jl
+++ b/test/test_system_data.jl
@@ -1,3 +1,12 @@
+struct SpecialComparable
+    n::Int64
+end
+
+function IS.compare_values(a::SpecialComparable, b::SpecialComparable; kwargs...)
+    @info "reached custom compare_values"
+    return false
+end
+
 @testset "Test components" begin
     data = IS.SystemData()
 
@@ -164,14 +173,14 @@ end
     @test IS.compare_values(NaN, NaN)  # True by default because the default match_fn is now `IS.isequivalent`
     @test IS.compare_values(0.0, -0.0)
     @test IS.compare_values(0, -0.0)
-    @test !IS.compare_values(0.0, -0.0; match_fn = isequal)
-    @test !IS.compare_values(NaN, NaN; match_fn = ==)
+    @test !IS.compare_values(isequal, 0.0, -0.0)
+    @test !IS.compare_values(==, NaN, NaN)
     @test !IS.compare_values(1.0, 1.0 + 1e-8)
-    @test IS.compare_values(1.0, 1.0 + 1e-8; match_fn = isapprox)
+    @test IS.compare_values(isapprox, 1.0, 1.0 + 1e-8)
 
     my_match_fn(a::String, b::String) = (a == b)
     my_match_fn(a::Float64, b::Float64) = isapprox(a, b; atol = 0.1)
-    IS.compare_values(["a", 1.0], ["a", 1.05]; match_fn = my_match_fn)
+    IS.compare_values(my_match_fn, ["a", 1.0], ["a", 1.05])
 
     my_match_fn_2(a::Int64, b::Int64) = isapprox(a, b; rtol = 0.1)
     my_match_fn_2(a, b) = isequal(a, b)
@@ -179,7 +188,19 @@ end
     IS.add_component!(data3, IS.TestComponent("a", 100))
     data4 = IS.SystemData()
     IS.add_component!(data4, IS.TestComponent("a", 105))
-    @test IS.compare_values(data3, data4; match_fn = my_match_fn_2)
+    @test IS.compare_values(my_match_fn_2, data3, data4)
+
+    special1 = SpecialComparable(1)
+    @test !(@test_logs (:info, "reached custom compare_values") IS.compare_values(
+        special1,
+        special1,
+    ))
+    @test !(@test_logs (:info, "reached custom compare_values") IS.compare_values(
+        nothing,
+        special1,
+        special1,
+    ))
+    @test IS.compare_values(==, special1, special1)
 end
 
 @testset "Test compression settings" begin


### PR DESCRIPTION
Previously, at the leaves of `compare_values`'s recursion tree, it would mostly test equality using the `==` operator, sometimes the `Base.isequal` function. This PR lets a sophisticated user specify a custom equality predicate `match_fn` to override that behavior, such as to test a more approximate equality on a system when it is exported to a certain format and reimported. It also standardizes the default `match_fn` to
```julia
isequivalent(x, y) = isequal(x, y) || (x == y)
```
, which is `true` for `NaN, NaN` (unlike `==`) and for `-0.0, 0.0` (unlike `isequal`). Is that a violation of SemVer?