### PR TITLE
Document function arguments and move docstring details over from PSY

### DIFF
--- a/src/deterministic.jl
+++ b/src/deterministic.jl
@@ -314,7 +314,19 @@ eltype_data(forecast::Deterministic) = eltype_data_common(forecast)
 get_initial_times(forecast::Deterministic) = get_initial_times_common(forecast)
 get_initial_timestamp(forecast::Deterministic) = get_initial_timestamp_common(forecast)
 get_interval(forecast::Deterministic) = get_interval_common(forecast)
+
+"""
+Iterate over the windows in a forecast
+
+# Examples
+```julia
+for window in iterate_windows(forecast)
+    @show values(maximum(window))
+end
+```
+"""
 iterate_windows(forecast::Deterministic) = iterate_windows_common(forecast)
+
 get_window(f::Deterministic, initial_time::Dates.DateTime; len = nothing) =
     get_window_common(f, initial_time; len = len)
 

--- a/src/deterministic.jl
+++ b/src/deterministic.jl
@@ -199,6 +199,30 @@ Construct Deterministic that shares the data from an existing instance.
 
 This is useful in cases where you want a component to use the same time series data for
 two different attributes.
+
+# Examples
+```julia
+resolution = Dates.Hour(1)
+data = Dict(
+    DateTime("2020-01-01T00:00:00") => ones(24),
+    DateTime("2020-01-01T01:00:00") => ones(24),
+)
+# Define a Deterministic for the first attribute
+forecast_max_active_power = Deterministic(
+    "max_active_power",
+    data,
+    resolution,
+    scaling_factor_multiplier = get_max_active_power,
+)
+add_time_series!(sys, generator, forecast_max_active_power)
+# Reuse time series for second attribute
+forecast_max_reactive_power = Deterministic(
+    forecast_max_active_power,
+    "max_reactive_power"
+    scaling_factor_multiplier = get_max_reactive_power,
+)
+add_time_series!(sys, generator, forecast_max_reactive_power)
+```
 """
 function Deterministic(
     src::Deterministic,

--- a/src/deterministic_single_time_series.jl
+++ b/src/deterministic_single_time_series.jl
@@ -7,11 +7,19 @@
         horizon::Int
     end
 
-A deterministic forecast for a particular data field in a Component that wraps a SingleTimeSeries.
+A deterministic forecast that wraps a [`SingleTimeSeries`](@ref)
+
+`DeterministicSingleTimeSeries` behaves exactly like a [`Deterministic`](@ref), but
+instead of storing windows at each initial time it provides a view into the existing
+`SingleTimeSeries` at incrementing offsets. This avoids large data duplications when 
+there are the overlapping windows between forecasts. 
+
+Can be used as a perfect forecast based on historical data when real forecast data
+is unavailable. 
 
 # Arguments
 
-  - `single_time_series::SingleTimeSeries`: wrapped SingleTimeSeries object
+  - `single_time_series::SingleTimeSeries`: wrapped `SingleTimeSeries` object
   - `initial_timestamp::Dates.DateTime`: time series availability time
   - `interval::Dates.Period`: time step between forecast windows
   - `count::Int`: number of forecast windows

--- a/src/deterministic_single_time_series.jl
+++ b/src/deterministic_single_time_series.jl
@@ -138,6 +138,16 @@ function get_window(
     return ta[initial_time:resolution:end_time]
 end
 
+"""
+Iterate over the windows in a forecast
+
+# Examples
+```julia
+for window in iterate_windows(forecast)
+    @show values(maximum(window))
+end
+```
+"""
 function iterate_windows(forecast::DeterministicSingleTimeSeries)
     if get_count(forecast) == 1
         return (get_window(forecast, get_initial_timestamp(forecast)),)

--- a/src/forecasts.jl
+++ b/src/forecasts.jl
@@ -3,6 +3,7 @@ Supertype for forecast time series
 Yeah
 Current concrete subtypes are:
 - [Deterministic](@ref)
+- [DeterministicSingleTimeSeries](@ref)
 - [Scenarios](@ref)
 - [Probabilistic](@ref)
 

--- a/src/forecasts.jl
+++ b/src/forecasts.jl
@@ -1,13 +1,21 @@
-abstract type Forecast <: TimeSeriesData end
+"""
+Supertype for forecast time series
+Yeah
+Current concrete subtypes are:
+- [Deterministic](@ref)
+- [Scenarios](@ref)
+- [Probabilistic](@ref)
 
-# Subtypes of Forecast must implement
-# - get_horizon_count
-# - get_initial_times
-# - get_initial_timestamp
-# - get_name
-# - get_scaling_factor_multiplier
-# - get_window
-# - iterate_windows
+Subtypes of Forecast must implement:
+- `get_horizon_count`
+- `get_initial_times`
+- `get_initial_timestamp`
+- `get_name`
+- `get_scaling_factor_multiplier`
+- `get_window`
+- `iterate_windows`
+"""
+abstract type Forecast <: TimeSeriesData end
 
 Base.length(ts::Forecast) = get_count(ts)
 

--- a/src/forecasts.jl
+++ b/src/forecasts.jl
@@ -1,7 +1,5 @@
 """
-Supertype for forecast time series
-Yeah
-Current concrete subtypes are:
+Supertype for forecast time series current concrete subtypes are:
 - [Deterministic](@ref)
 - [DeterministicSingleTimeSeries](@ref)
 - [Scenarios](@ref)

--- a/src/forecasts.jl
+++ b/src/forecasts.jl
@@ -1,9 +1,10 @@
 """
-Supertype for forecast time series current concrete subtypes are:
-- [Deterministic](@ref)
-- [DeterministicSingleTimeSeries](@ref)
-- [Scenarios](@ref)
-- [Probabilistic](@ref)
+Supertype for forecast time series
+Current concrete subtypes are:
+- [`Deterministic`](@ref)
+- [`DeterministicSingleTimeSeries`](@ref)
+- [`Scenarios`](@ref)
+- [`Probabilistic`](@ref)
 
 Subtypes of Forecast must implement:
 - `get_horizon_count`

--- a/src/probabilistic.jl
+++ b/src/probabilistic.jl
@@ -302,4 +302,15 @@ get_initial_timestamp(forecast::Probabilistic) = get_initial_timestamp_common(fo
 get_interval(forecast::Probabilistic) = get_interval_common(forecast)
 get_window(f::Probabilistic, initial_time::Dates.DateTime; len = nothing) =
     get_window_common(f, initial_time; len = len)
+
+"""
+Iterate over the windows in a forecast
+
+# Examples
+```julia
+for window in iterate_windows(forecast)
+    @show values(maximum(window))
+end
+```
+"""
 iterate_windows(forecast::Probabilistic) = iterate_windows_common(forecast)

--- a/src/scenarios.jl
+++ b/src/scenarios.jl
@@ -260,4 +260,15 @@ get_initial_timestamp(forecast::Scenarios) = get_initial_timestamp_common(foreca
 get_interval(forecast::Scenarios) = get_interval_common(forecast)
 get_window(f::Scenarios, initial_time::Dates.DateTime; len = nothing) =
     get_window_common(f, initial_time; len = len)
+
+"""
+Iterate over the windows in a forecast
+
+# Examples
+```julia
+for window in iterate_windows(forecast)
+    @show values(maximum(window))
+end
+```
+"""
 iterate_windows(forecast::Scenarios) = iterate_windows_common(forecast)

--- a/src/single_time_series.jl
+++ b/src/single_time_series.jl
@@ -6,12 +6,13 @@
         internal::InfrastructureSystemsInternal
     end
 
-A deterministic forecast for a particular data field in a Component.
+A single column of time series data for a particular data field in a Component.
 
 # Arguments
 
   - `name::String`: user-defined name
   - `data::TimeSeries.TimeArray`: timestamp - scalingfactor
+  - `resolution::Dates.Period`: Time duration between steps in the time series. The resolution must be the same throughout the time series
   - `scaling_factor_multiplier::Union{Nothing, Function}`: Applicable when the time series
     data are scaling factors. Called on the associated component to convert the values.
   - `internal::InfrastructureSystemsInternal`
@@ -21,6 +22,7 @@ mutable struct SingleTimeSeries <: StaticTimeSeries
     name::String
     "timestamp - scalingfactor"
     data::TimeSeries.TimeArray
+    "resolution of the time series. The resolution cannot change during the time series."
     resolution::Dates.Period
     "Applicable when the time series data are scaling factors. Called on the associated component to convert the values."
     scaling_factor_multiplier::Union{Nothing, Function}

--- a/src/single_time_series.jl
+++ b/src/single_time_series.jl
@@ -8,6 +8,10 @@
 
 A single column of time series data for a particular data field in a Component.
 
+In contrast with a forecast, this can represent one continual time series,
+such as a series of historical measurements or realizations or a single scenario
+(e.g. a weather year or different input assumptions).
+
 # Arguments
 
   - `name::String`: user-defined name

--- a/src/time_series_cache.jl
+++ b/src/time_series_cache.jl
@@ -88,6 +88,13 @@ Reads from storage if the data is not already in cache.
 # Arguments
 
   - `cache::StaticTimeSeriesCache`: cached instance
+
+# Examples
+```julia
+cache = ForecastCache(Deterministic, component, "max_active_power")
+window1 = get_next_time_series_array!(cache)
+window2 = get_next_time_series_array!(cache)
+```
 """
 function get_next_time_series_array!(cache::TimeSeriesCache)
     next_time = get_next_time(cache)

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -65,7 +65,13 @@ function get_time_series(
 end
 
 """
-Return a time series corresponding to the given parameters.
+Return the exact stored data in a time series, using a time series key look up
+
+This will load all forecast windows into memory by default. Be aware of how much data is stored.
+
+Specify start_time and len if you only need a subset of data.
+
+Does not apply a scaling factor multiplier.
 
 # Arguments
 

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -489,7 +489,8 @@ function get_time_series_values(
 end
 
 """
-Return a vector of values for one forecast window from a cached Forecast instance.
+Return an vector of timeseries data without timestamps for one forecast window from a
+cached `Forecast` instance.
 
 # Arguments
   - `owner::TimeSeriesOwners`: Component or attribute containing the time series
@@ -533,8 +534,7 @@ function get_time_series_values(
 end
 
 """
-Return a vector of values from a cached StaticTimeSeries instance for the requested time
-series parameters.
+Return an vector of timeseries data without timestamps from a cached `StaticTimeSeries` instance
 
 # Arguments
   - `owner::TimeSeriesOwners`: Component or attribute containing the time series

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -171,7 +171,7 @@ aware of how much data is stored.
 Specify `start_time` and `len` if you only need a subset of data.
 
 # Arguments
-  - `::Type{T}`: Concrete subtype of `TimeSeriesData` to return
+  - `::Type{T}`: the type of time series (a concrete subtype of `TimeSeriesData`)
   - `owner::TimeSeriesOwners`: Component or attribute containing the time series
   - `name::AbstractString`: name of time series
   - `start_time::Union{Nothing, Dates.DateTime} = nothing`: If nothing, use the
@@ -279,7 +279,7 @@ factor multiplier by default.
 
 # Arguments
   - `owner::TimeSeriesOwners`: Component or attribute containing the time series
-  - `time_series::StaticTimeSeries`
+  - `time_series::StaticTimeSeries`: subtype of `StaticTimeSeries` (e.g., `SingleTimeSeries`)
   - `start_time::Union{Nothing, Dates.DateTime} = nothing`: the first timestamp to retrieve.
     If nothing, use the `initial_timestamp` of the time series.
   - `len::Union{Nothing, Int} = nothing`: Length of time-series to retrieve (i.e. number
@@ -311,6 +311,17 @@ end
 
 """
 Return a vector of timestamps from storage for the given time series parameters.
+
+# Arguments
+  - `::Type{T}`: the type of time series (a concrete subtype of `TimeSeriesData`)
+  - `owner::TimeSeriesOwners`: Component or attribute containing the time series
+  - `name::AbstractString`: name of time series
+  - `start_time::Union{Nothing, Dates.DateTime} = nothing`: If nothing, use the
+    `initial_timestamp` of the time series. If T is a subtype of [`Forecast`](@ref) then
+    `start_time` must be the first timestamp of a window.
+  - `len::Union{Nothing, Int} = nothing`: Length of time-series to retrieve (i.e. number of
+    timestamps). If nothing, use the entire length.
+  - `features`
 
 See also: [`get_time_series_array`](@ref get_time_series_array(
     ::Type{T},
@@ -353,6 +364,14 @@ end
 """
 Return a vector of timestamps from a cached Forecast instance.
 
+# Arguments
+  - `owner::TimeSeriesOwners`: Component or attribute containing the time series
+  - `forecast::Forecast`: a concrete subtype of [`Forecast`](@ref)
+  - `start_time::Union{Nothing, Dates.DateTime} = nothing`: the first timestamp of one of
+    the forecast windows
+  - `len::Union{Nothing, Int} = nothing`: Length of time-series to retrieve (i.e. number of
+    timestamps). If nothing, use the entire length.
+
 See also: [`get_time_series_array`](@ref get_time_series_array(
     owner::TimeSeriesOwners,
     forecast::Forecast,
@@ -381,6 +400,14 @@ end
 """
 Return a vector of timestamps from a cached StaticTimeSeries instance.
 
+# Arguments
+  - `owner::TimeSeriesOwners`: Component or attribute containing the time series
+  - `time_series::StaticTimeSeries`: subtype of `StaticTimeSeries` (e.g., `SingleTimeSeries`)
+  - `start_time::Union{Nothing, Dates.DateTime} = nothing`: the first timestamp to retrieve.
+    If nothing, use the `initial_timestamp` of the time series.
+  - `len::Union{Nothing, Int} = nothing`: Length of time-series to retrieve (i.e. number
+    of timestamps). If nothing, use the entire length
+
 See also: [`get_time_series_array`](@ref get_time_series_array(
     owner::TimeSeriesOwners,
     time_series::StaticTimeSeries,
@@ -402,10 +429,23 @@ function get_time_series_timestamps(
 end
 
 """
-Return an Array of values from storage for the requested time series parameters.
+Return an vector of timeseries data without timestamps from storage
 
 If the data size is small and this will be called many times, consider using the version
-that accepts a cached TimeSeriesData instance.
+that accepts a cached `TimeSeriesData` instance.
+
+# Arguments
+  - `::Type{T}`: type of the time series (a concrete subtype of `TimeSeriesData`)
+  - `owner::TimeSeriesOwners`: Component or attribute containing the time series
+  - `name::AbstractString`: name of time series
+  - `start_time::Union{Nothing, Dates.DateTime} = nothing`: If nothing, use the
+    `initial_timestamp` of the time series. If T is a subtype of [`Forecast`](@ref) then
+    `start_time` must be the first timestamp of a window.
+  - `len::Union{Nothing, Int} = nothing`: Length of time-series to retrieve (i.e. number of
+    timestamps). If nothing, use the entire length.
+  - `ignore_scaling_factors = false`: If `true`, the time-series data will be multiplied by the
+    result of calling the stored `scaling_factor_multiplier` function on the `owner`
+  - `features`
 
 See also: [`get_time_series_array`](@ref get_time_series_array(
     ::Type{T},
@@ -449,7 +489,17 @@ function get_time_series_values(
 end
 
 """
-Return an Array of values for one forecast window from a cached Forecast instance.
+Return a vector of values for one forecast window from a cached Forecast instance.
+
+# Arguments
+  - `owner::TimeSeriesOwners`: Component or attribute containing the time series
+  - `forecast::Forecast`: a concrete subtype of [`Forecast`](@ref)
+  - `start_time::Union{Nothing, Dates.DateTime} = nothing`: the first timestamp of one of
+    the forecast windows
+  - `len::Union{Nothing, Int} = nothing`: Length of time-series to retrieve (i.e. number of
+    timestamps). If nothing, use the entire length.
+  - `ignore_scaling_factors = false`: If `true`, the time-series data will be multiplied by the
+    result of calling the stored `scaling_factor_multiplier` function on the `owner`
 
 See also: [`get_time_series_array`](@ref get_time_series_array(
     owner::TimeSeriesOwners,
@@ -483,9 +533,18 @@ function get_time_series_values(
 end
 
 """
-Return an Array of values from a cached StaticTimeSeries instance for the requested time
+Return a vector of values from a cached StaticTimeSeries instance for the requested time
 series parameters.
 
+# Arguments
+  - `owner::TimeSeriesOwners`: Component or attribute containing the time series
+  - `time_series::StaticTimeSeries`: subtype of `StaticTimeSeries` (e.g., `SingleTimeSeries`)
+  - `start_time::Union{Nothing, Dates.DateTime} = nothing`: the first timestamp to retrieve.
+    If nothing, use the `initial_timestamp` of the time series.
+  - `len::Union{Nothing, Int} = nothing`: Length of time-series to retrieve (i.e. number
+    of timestamps). If nothing, use the entire length
+  - `ignore_scaling_factors = false`: If `true`, the time-series data will be multiplied by the
+    result of calling the stored `scaling_factor_multiplier` function on the `owner`
 
 See also: [`get_time_series_array`](@ref get_time_series_array(
     owner::TimeSeriesOwners,

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -19,7 +19,14 @@ function get_time_series_storage(owner::TimeSeriesOwners)
 end
 
 """
-Return a time series corresponding to the given parameters.
+Return the exact stored data in a time series
+
+This will load all forecast windows into memory by default. Be
+aware of how much data is stored.
+
+Specify `start_time` and `len` if you only need a subset of data.
+
+Does not apply a scaling factor multiplier. See also: [`get_time_series_array`](@ref).
 
 # Arguments
 
@@ -28,7 +35,7 @@ Return a time series corresponding to the given parameters.
   - `name::AbstractString`: name of time series
   - `start_time::Union{Nothing, Dates.DateTime} = nothing`: If nothing, use the
     `initial_timestamp` of the time series. If T is a subtype of Forecast then `start_time`
-    must be the first timstamp of a window.
+    must be the first timestamp of a window.
   - `len::Union{Nothing, Int} = nothing`: Length in the time dimension. If nothing, use the
     entire length.
   - `count::Union{Nothing, Int} = nothing`: Only applicable to subtypes of Forecast. Number
@@ -62,7 +69,7 @@ Return a time series corresponding to the given parameters.
   - `key::TimeSeriesKey`: the time series' key
   - `start_time::Union{Nothing, Dates.DateTime} = nothing`: If nothing, use the
     `initial_timestamp` of the time series. If the time series is a subtype of Forecast
-    then `start_time` must be the first timstamp of a window.
+    then `start_time` must be the first timestamp of a window.
   - `len::Union{Nothing, Int} = nothing`: Length in the time dimension. If nothing, use the
     entire length.
   - `count::Union{Nothing, Int} = nothing`: Only applicable to subtypes of Forecast. Number
@@ -151,10 +158,29 @@ function get_time_series_metadata(
 end
 
 """
-Return a TimeSeries.TimeArray from storage for the given time series parameters.
+Return a `TimeSeries.TimeArray` from storage for the given time series parameters.
 
-If the data are scaling factors then the stored scaling_factor_multiplier will be called on
-the owner and applied to the data unless ignore_scaling_factors is true.
+If the time series data are scaling factors, the returned data will be scaled by the scaling
+factor multiplier by default.
+
+This will load all forecast windows into memory by default. Be
+aware of how much data is stored.
+
+Specify `start_time` and `len` if you only need a subset of data.
+
+# Arguments
+  - `::Type{T}`: Concrete subtype of `TimeSeriesData` to return
+  - `owner::TimeSeriesOwners`: Component or attribute containing the time series
+  - `name::AbstractString`: name of time series
+  - `start_time::Union{Nothing, Dates.DateTime} = nothing`: If nothing, use the
+    `initial_timestamp` of the time series. If T is a subtype of [`Forecast`](@ref) then
+    `start_time` must be the first timestamp of a window.
+  - `len::Union{Nothing, Int} = nothing`: Length of time-series to retrieve (i.e. number of
+    timestamps). If nothing, use the entire length.
+  - `ignore_scaling_factors = false`: If `true`, the time-series data will be multiplied by the
+    result of calling the stored `scaling_factor_multiplier` function on the `owner`
+
+See also: [`get_time_series`](@ref)
 """
 function get_time_series_array(
     ::Type{T},
@@ -188,10 +214,21 @@ function get_time_series_array(
 end
 
 """
-Return a TimeSeries.TimeArray for one forecast window from a cached Forecast instance.
+Return a `TimeSeries.TimeArray` for one forecast window from a cached [`Forecast`](@ref)
+instance
 
-If the data are scaling factors then the stored scaling_factor_multiplier will be called on
-the owner and applied to the data unless ignore_scaling_factors is true.
+If the time series data are scaling factors, the returned data will be scaled by the scaling
+factor multiplier by default.
+
+# Arguments
+  - `owner::TimeSeriesOwners`: Component or attribute containing the time series
+  - `forecast::Forecast`: a concrete subtype of [`Forecast`](@ref)
+  - `start_time::Union{Nothing, Dates.DateTime} = nothing`: the first timestamp of one of
+    the forecast windows
+  - `len::Union{Nothing, Int} = nothing`: Length of time-series to retrieve (i.e. number of
+    timestamps). If nothing, use the entire length.
+  - `ignore_scaling_factors = false`: If `true`, the time-series data will be multiplied by the
+    result of calling the stored `scaling_factor_multiplier` function on the `owner`
 
 See also [`ForecastCache`](@ref).
 """
@@ -206,10 +243,22 @@ function get_time_series_array(
 end
 
 """
-Return a TimeSeries.TimeArray from a cached StaticTimeSeries instance.
+Return a `TimeSeries.TimeArray` from a cached `StaticTimeSeries` instance.
 
-If the data are scaling factors then the stored scaling_factor_multiplier will be called on
-the owner and applied to the data unless ignore_scaling_factors is true.
+
+
+If the time series data are scaling factors, the returned data will be scaled by the scaling
+factor multiplier by default.
+
+# Arguments
+  - `owner::TimeSeriesOwners`: Component or attribute containing the time series
+  - `time_series::StaticTimeSeries`
+  - `start_time::Union{Nothing, Dates.DateTime} = nothing`: the first timestamp to retrieve.
+    If nothing, use the `initial_timestamp` of the time series.
+  - `len::Union{Nothing, Int} = nothing`: Length of time-series to retrieve (i.e. number
+    of timestamps). If nothing, use the entire length
+  - `ignore_scaling_factors = false`: If `true`, the time-series data will be multiplied by the
+    result of calling the stored `scaling_factor_multiplier` function on the `owner`
 
 See also [`StaticTimeSeriesCache`](@ref).
 """

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -26,11 +26,11 @@ aware of how much data is stored.
 
 Specify `start_time` and `len` if you only need a subset of data.
 
-Does not apply a scaling factor multiplier. See also: [`get_time_series_array`](@ref).
+Does not apply a scaling factor multiplier.
 
 # Arguments
 
-  - `::Type{T}`: Concrete subtype of TimeSeriesData to return
+  - `::Type{T}`: Concrete subtype of `TimeSeriesData` to return
   - `owner::TimeSeriesOwners`: Component or attribute containing the time series
   - `name::AbstractString`: name of time series
   - `start_time::Union{Nothing, Dates.DateTime} = nothing`: If nothing, use the
@@ -40,6 +40,8 @@ Does not apply a scaling factor multiplier. See also: [`get_time_series_array`](
     entire length.
   - `count::Union{Nothing, Int} = nothing`: Only applicable to subtypes of Forecast. Number
     of forecast windows starting at `start_time` to return. Defaults to all available.
+
+See also: [`get_time_series_array`](@ref), [`get_time_series_values`](@ref).
 """
 function get_time_series(
     ::Type{T},
@@ -180,7 +182,23 @@ Specify `start_time` and `len` if you only need a subset of data.
   - `ignore_scaling_factors = false`: If `true`, the time-series data will be multiplied by the
     result of calling the stored `scaling_factor_multiplier` function on the `owner`
 
-See also: [`get_time_series`](@ref)
+See also: [`get_time_series_values`](@ref get_time_series_values(
+    ::Type{T},
+    owner::TimeSeriesOwners,
+    name::AbstractString;
+    start_time::Union{Nothing, Dates.DateTime} = nothing,
+    len::Union{Nothing, Int} = nothing,
+    ignore_scaling_factors = false,
+features...,) where {T <: TimeSeriesData}),
+[`get_time_series_timestamps`](@ref get_time_series_timestamps(
+    ::Type{T},
+    owner::TimeSeriesOwners,
+    name::AbstractString;
+    start_time::Union{Nothing, Dates.DateTime} = nothing,
+    len::Union{Nothing, Int} = nothing,
+    features...,
+) where {T <: TimeSeriesData}),
+ [`get_time_series`](@ref)
 """
 function get_time_series_array(
     ::Type{T},
@@ -230,7 +248,18 @@ factor multiplier by default.
   - `ignore_scaling_factors = false`: If `true`, the time-series data will be multiplied by the
     result of calling the stored `scaling_factor_multiplier` function on the `owner`
 
-See also [`ForecastCache`](@ref).
+See also [`get_time_series_values`](@ref get_time_series_values(
+    owner::TimeSeriesOwners,
+    forecast::Forecast,
+    start_time::Dates.DateTime;
+    len::Union{Nothing, Int} = nothing,
+    ignore_scaling_factors = false,
+)), [`get_time_series_timestamps`](@ref get_time_series_timestamps(
+    owner::TimeSeriesOwners,
+    forecast::Forecast,
+    start_time::Union{Nothing, Dates.DateTime} = nothing;
+    len::Union{Nothing, Int} = nothing,
+)), [`ForecastCache`](@ref).
 """
 function get_time_series_array(
     owner::TimeSeriesOwners,
@@ -245,8 +274,6 @@ end
 """
 Return a `TimeSeries.TimeArray` from a cached `StaticTimeSeries` instance.
 
-
-
 If the time series data are scaling factors, the returned data will be scaled by the scaling
 factor multiplier by default.
 
@@ -260,7 +287,9 @@ factor multiplier by default.
   - `ignore_scaling_factors = false`: If `true`, the time-series data will be multiplied by the
     result of calling the stored `scaling_factor_multiplier` function on the `owner`
 
-See also [`StaticTimeSeriesCache`](@ref).
+See also: [`get_time_series_values`](@ref get_time_series_values(owner::TimeSeriesOwners, time_series::StaticTimeSeries, start_time::Union{Nothing, Dates.DateTime} = nothing; len::Union{Nothing, Int} = nothing, ignore_scaling_factors = false)),
+[`get_time_series_timestamps`](@ref get_time_series_timestamps(owner::TimeSeriesOwners, time_series::StaticTimeSeries, start_time::Union{Nothing, Dates.DateTime} = nothing; len::Union{Nothing, Int} = nothing,)),
+[`StaticTimeSeriesCache`](@ref).
 """
 function get_time_series_array(
     owner::TimeSeriesOwners,
@@ -282,6 +311,24 @@ end
 
 """
 Return a vector of timestamps from storage for the given time series parameters.
+
+See also: [`get_time_series_array`](@ref get_time_series_array(
+    ::Type{T},
+    owner::TimeSeriesOwners,
+    name::AbstractString;
+    start_time::Union{Nothing, Dates.DateTime} = nothing,
+    len::Union{Nothing, Int} = nothing,
+    ignore_scaling_factors = false,
+    features...,
+) where {T <: TimeSeriesData}),
+[`get_time_series_values`](@ref get_time_series_values(
+    ::Type{T},
+    owner::TimeSeriesOwners,
+    name::AbstractString;
+    start_time::Union{Nothing, Dates.DateTime} = nothing,
+    len::Union{Nothing, Int} = nothing,
+    ignore_scaling_factors = false,
+features...,) where {T <: TimeSeriesData})
 """
 function get_time_series_timestamps(
     ::Type{T},
@@ -305,6 +352,20 @@ end
 
 """
 Return a vector of timestamps from a cached Forecast instance.
+
+See also: [`get_time_series_array`](@ref get_time_series_array(
+    owner::TimeSeriesOwners,
+    forecast::Forecast,
+    start_time::Dates.DateTime;
+    len = nothing,
+    ignore_scaling_factors = false,
+)), [`get_time_series_values`](@ref get_time_series_values(
+    owner::TimeSeriesOwners,
+    forecast::Forecast,
+    start_time::Dates.DateTime;
+    len::Union{Nothing, Int} = nothing,
+    ignore_scaling_factors = false,
+)), [`ForecastCache`](@ref).
 """
 function get_time_series_timestamps(
     owner::TimeSeriesOwners,
@@ -319,6 +380,15 @@ end
 
 """
 Return a vector of timestamps from a cached StaticTimeSeries instance.
+
+See also: [`get_time_series_array`](@ref get_time_series_array(
+    owner::TimeSeriesOwners,
+    time_series::StaticTimeSeries,
+    start_time::Union{Nothing, Dates.DateTime} = nothing;
+    len::Union{Nothing, Int} = nothing,
+    ignore_scaling_factors = false,
+)), [`get_time_series_values`](@ref get_time_series_values(owner::TimeSeriesOwners, time_series::StaticTimeSeries, start_time::Union{Nothing, Dates.DateTime} = nothing; len::Union{Nothing, Int} = nothing, ignore_scaling_factors = false)),
+[`StaticTimeSeriesCache`](@ref).
 """
 function get_time_series_timestamps(
     owner::TimeSeriesOwners,
@@ -336,6 +406,25 @@ Return an Array of values from storage for the requested time series parameters.
 
 If the data size is small and this will be called many times, consider using the version
 that accepts a cached TimeSeriesData instance.
+
+See also: [`get_time_series_array`](@ref get_time_series_array(
+    ::Type{T},
+    owner::TimeSeriesOwners,
+    name::AbstractString;
+    start_time::Union{Nothing, Dates.DateTime} = nothing,
+    len::Union{Nothing, Int} = nothing,
+    ignore_scaling_factors = false,
+    features...,
+) where {T <: TimeSeriesData}),
+[`get_time_series_timestamps`](@ref get_time_series_timestamps(
+    ::Type{T},
+    owner::TimeSeriesOwners,
+    name::AbstractString;
+    start_time::Union{Nothing, Dates.DateTime} = nothing,
+    len::Union{Nothing, Int} = nothing,
+    features...,
+) where {T <: TimeSeriesData}),
+[`get_time_series`](@ref)
 """
 function get_time_series_values(
     ::Type{T},
@@ -361,6 +450,19 @@ end
 
 """
 Return an Array of values for one forecast window from a cached Forecast instance.
+
+See also: [`get_time_series_array`](@ref get_time_series_array(
+    owner::TimeSeriesOwners,
+    forecast::Forecast,
+    start_time::Dates.DateTime;
+    len = nothing,
+    ignore_scaling_factors = false,
+)), [`get_time_series_timestamps`](@ref get_time_series_timestamps(
+    owner::TimeSeriesOwners,
+    forecast::Forecast,
+    start_time::Union{Nothing, Dates.DateTime} = nothing;
+    len::Union{Nothing, Int} = nothing,
+)), [`ForecastCache`](@ref).
 """
 function get_time_series_values(
     owner::TimeSeriesOwners,
@@ -383,6 +485,16 @@ end
 """
 Return an Array of values from a cached StaticTimeSeries instance for the requested time
 series parameters.
+
+
+See also: [`get_time_series_array`](@ref get_time_series_array(
+    owner::TimeSeriesOwners,
+    time_series::StaticTimeSeries,
+    start_time::Union{Nothing, Dates.DateTime} = nothing;
+    len::Union{Nothing, Int} = nothing,
+    ignore_scaling_factors = false,
+)), [`get_time_series_timestamps`](@ref get_time_series_timestamps(owner::TimeSeriesOwners, time_series::StaticTimeSeries, start_time::Union{Nothing, Dates.DateTime} = nothing; len::Union{Nothing, Int} = nothing,)),
+[`StaticTimeSeriesCache`](@ref).
 """
 function get_time_series_values(
     owner::TimeSeriesOwners,

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -40,7 +40,7 @@ Does not apply a scaling factor multiplier.
     entire length.
   - `count::Union{Nothing, Int} = nothing`: Only applicable to subtypes of Forecast. Number
     of forecast windows starting at `start_time` to return. Defaults to all available.
-  - `features`: User-defined tags that differentiate multiple time series arrays for the
+  - `features...`: User-defined tags that differentiate multiple time series arrays for the
     same component attribute, such as different arrays for different scenarios or years
 
 See also: [`get_time_series_array`](@ref), [`get_time_series_values`](@ref).
@@ -78,7 +78,7 @@ Return a time series corresponding to the given parameters.
     entire length.
   - `count::Union{Nothing, Int} = nothing`: Only applicable to subtypes of Forecast. Number
     of forecast windows starting at `start_time` to return. Defaults to all available.
-  - `features`: User-defined tags that differentiate multiple time series arrays for the
+  - `features...`: User-defined tags that differentiate multiple time series arrays for the
     same component attribute, such as different arrays for different scenarios or years
 """
 function get_time_series(
@@ -185,7 +185,7 @@ Specify `start_time` and `len` if you only need a subset of data.
     timestamps). If nothing, use the entire length.
   - `ignore_scaling_factors = false`: If `true`, the time-series data will be multiplied by the
     result of calling the stored `scaling_factor_multiplier` function on the `owner`
-  - `features`: User-defined tags that differentiate multiple time series arrays for the
+  - `features...`: User-defined tags that differentiate multiple time series arrays for the
     same component attribute, such as different arrays for different scenarios or years
 
 See also: [`get_time_series_values`](@ref get_time_series_values(
@@ -327,7 +327,7 @@ Return a vector of timestamps from storage for the given time series parameters.
     `start_time` must be the first timestamp of a window.
   - `len::Union{Nothing, Int} = nothing`: Length of time-series to retrieve (i.e. number of
     timestamps). If nothing, use the entire length.
-  - `features`: User-defined tags that differentiate multiple time series arrays for the
+  - `features...`: User-defined tags that differentiate multiple time series arrays for the
     same component attribute, such as different arrays for different scenarios or years
 
 See also: [`get_time_series_array`](@ref get_time_series_array(
@@ -452,7 +452,7 @@ that accepts a cached `TimeSeriesData` instance.
     timestamps). If nothing, use the entire length.
   - `ignore_scaling_factors = false`: If `true`, the time-series data will be multiplied by the
     result of calling the stored `scaling_factor_multiplier` function on the `owner`
-  - `features`: User-defined tags that differentiate multiple time series arrays for the
+  - `features...`: User-defined tags that differentiate multiple time series arrays for the
     same component attribute, such as different arrays for different scenarios or years
 
 See also: [`get_time_series_array`](@ref get_time_series_array(

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -40,6 +40,8 @@ Does not apply a scaling factor multiplier.
     entire length.
   - `count::Union{Nothing, Int} = nothing`: Only applicable to subtypes of Forecast. Number
     of forecast windows starting at `start_time` to return. Defaults to all available.
+  - `features`: User-defined tags that differentiate multiple time series arrays for the
+    same component attribute, such as different arrays for different scenarios or years
 
 See also: [`get_time_series_array`](@ref), [`get_time_series_values`](@ref).
 """
@@ -76,6 +78,8 @@ Return a time series corresponding to the given parameters.
     entire length.
   - `count::Union{Nothing, Int} = nothing`: Only applicable to subtypes of Forecast. Number
     of forecast windows starting at `start_time` to return. Defaults to all available.
+  - `features`: User-defined tags that differentiate multiple time series arrays for the
+    same component attribute, such as different arrays for different scenarios or years
 """
 function get_time_series(
     owner::TimeSeriesOwners,
@@ -181,6 +185,8 @@ Specify `start_time` and `len` if you only need a subset of data.
     timestamps). If nothing, use the entire length.
   - `ignore_scaling_factors = false`: If `true`, the time-series data will be multiplied by the
     result of calling the stored `scaling_factor_multiplier` function on the `owner`
+  - `features`: User-defined tags that differentiate multiple time series arrays for the
+    same component attribute, such as different arrays for different scenarios or years
 
 See also: [`get_time_series_values`](@ref get_time_series_values(
     ::Type{T},
@@ -321,7 +327,8 @@ Return a vector of timestamps from storage for the given time series parameters.
     `start_time` must be the first timestamp of a window.
   - `len::Union{Nothing, Int} = nothing`: Length of time-series to retrieve (i.e. number of
     timestamps). If nothing, use the entire length.
-  - `features`
+  - `features`: User-defined tags that differentiate multiple time series arrays for the
+    same component attribute, such as different arrays for different scenarios or years
 
 See also: [`get_time_series_array`](@ref get_time_series_array(
     ::Type{T},
@@ -445,7 +452,8 @@ that accepts a cached `TimeSeriesData` instance.
     timestamps). If nothing, use the entire length.
   - `ignore_scaling_factors = false`: If `true`, the time-series data will be multiplied by the
     result of calling the stored `scaling_factor_multiplier` function on the `owner`
-  - `features`
+  - `features`: User-defined tags that differentiate multiple time series arrays for the
+    same component attribute, such as different arrays for different scenarios or years
 
 See also: [`get_time_series_array`](@ref get_time_series_array(
     ::Type{T},

--- a/src/time_series_storage.jl
+++ b/src/time_series_storage.jl
@@ -19,8 +19,25 @@ const DEFAULT_COMPRESSION = false
 @scoped_enum(CompressionTypes, BLOSC = 0, DEFLATE = 1,)
 
 """
+    CompressionSettings(enabled, type, level, shuffle)
+
 Provides customization of HDF5 compression settings.
-Refer to the HDF5.jl and HDF5 documention for more information.
+
+$(TYPEDFIELDS)
+
+Refer to the [HDF5.jl](https://juliaio.github.io/HDF5.jl/stable/) and
+[HDF5](https://portal.hdfgroup.org/) documentation for more details on the
+options.
+
+# Example
+```julia
+settings = CompressionSettings(
+    enabled = true,
+    type = CompressionTypes.DEFLATE,  # BLOSC is also supported
+    level = 3,
+    shuffle = true,
+)
+```
 """
 struct CompressionSettings
     "Controls whether compression is enabled."


### PR DESCRIPTION
- documents arguments for Time series Interface functions used in PSY
- PSY modeler guides also contained details and examples about Time series functions, which have been moved or duplicated to the respective functions
- add some missing docstrings (e.g., iterate_windows)