### PR TITLE
Add missing or move incorrect semicolons

### DIFF
--- a/docs/src/dev_guide/logging.md
+++ b/docs/src/dev_guide/logging.md
@@ -110,7 +110,7 @@ Note that you can use `Logging.ConsoleLogger` if you don't have `TerminalLoggers
 ```julia
 console_logger = TerminalLogger(stderr, Logging.Error)
 
-open_file_logger("log.txt", Logging.Info) do file_logger
+open_file_logger("log.txt"; level = Logging.Info) do file_logger
     multi_logger = MultiLogger([console_logger, file_logger])
     global_logger(multi_logger)
 
@@ -125,7 +125,7 @@ try/finally block and reset the global logger upon exit.
 function run_tests()
     console_logger = TerminalLogger(stderr, Logging.Error)
 
-    open_file_logger("log.txt", Logging.Info) do file_logger
+    open_file_logger("log.txt"; level = Logging.Info) do file_logger
         multi_logger = MultiLogger([console_logger, file_logger])
         global_logger(multi_logger)
 

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -467,8 +467,8 @@ Call `collect` on the result to get an array.
   - `name = nothing`: Only return time_series matching this value.
 """
 function get_time_series_multiple(
-    data::SystemData,
-    filter_func = nothing;
+    data::SystemData;
+    filter_func = nothing,
     type = nothing,
     name = nothing,
 )

--- a/src/time_series_formats.jl
+++ b/src/time_series_formats.jl
@@ -14,8 +14,8 @@ Pass component_name when the file does not have the component name in a column h
 """
 function read_time_series(
     ::Type{T},
-    data_file::AbstractString,
-    component_name = nothing;
+    data_file::AbstractString;
+    component_name = nothing,
     kwargs...,
 ) where {T <: TimeSeriesData}
     if !isfile(data_file)
@@ -34,8 +34,8 @@ end
 function read_time_series(metadata::TimeSeriesFileMetadata; kwargs...)
     return read_time_series(
         metadata.time_series_type,
-        metadata.data_file,
-        metadata.component_name;
+        metadata.data_file;
+        component_name = metadata.component_name,
         kwargs...,
     )
 end
@@ -174,8 +174,8 @@ Pass component_name when the file does not have the component name in a column h
 function read_time_series(
     ::Type{T},
     ::Type{Deterministic},
-    file::CSV.File,
-    component_name = nothing;
+    file::CSV.File;
+    component_name = nothing,
     kwargs...,
 ) where {T <: TimeSeriesFormatDateTimeAsColumn}
     @debug "Read CSV data from $file." _group = LOG_GROUP_TIME_SERIES
@@ -201,8 +201,8 @@ This version of the function only has component_name to match the interface. It 
 function read_time_series(
     ::Type{T},
     ::Type{<:StaticTimeSeries},
-    file::CSV.File,
-    component_name = nothing;
+    file::CSV.File;
+    component_name = nothing,
     kwargs...,
 ) where {T <: Union{TimeSeriesFormatPeriodAsColumn, TimeSeriesFormatDateTimeAsColumn}}
     first_timestamp = get_timestamp(T, file, 1)
@@ -247,8 +247,8 @@ day is used.
 function read_time_series(
     ::Type{T},
     ::Type{<:StaticTimeSeries},
-    file::CSV.File,
-    component_name = nothing;
+    file::CSV.File;
+    component_name = nothing,
     kwargs...,
 ) where {T <: TimeSeriesFormatComponentsAsColumnsNoTime}
     first_timestamp = get(kwargs, :start_datetime, Dates.DateTime(Dates.today()))

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -89,7 +89,7 @@ Does not apply a scaling factor multiplier.
 """
 function get_time_series(
     owner::TimeSeriesOwners,
-    key::TimeSeriesKey,
+    key::TimeSeriesKey;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
     count::Union{Nothing, Int} = nothing,
@@ -122,8 +122,8 @@ Call `collect` on the result to get an array.
   - `name = nothing`: Only return time_series matching this value.
 """
 function get_time_series_multiple(
-    owner::TimeSeriesOwners,
-    filter_func = nothing;
+    owner::TimeSeriesOwners;
+    filter_func = nothing,
     type = nothing,
     name = nothing,
 )
@@ -305,8 +305,8 @@ See also: [`get_time_series_values`](@ref get_time_series_values(owner::TimeSeri
 """
 function get_time_series_array(
     owner::TimeSeriesOwners,
-    time_series::StaticTimeSeries,
-    start_time::Union{Nothing, Dates.DateTime} = nothing;
+    time_series::StaticTimeSeries;
+    start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
     ignore_scaling_factors = false,
 )
@@ -401,8 +401,8 @@ See also: [`get_time_series_array`](@ref get_time_series_array(
 """
 function get_time_series_timestamps(
     owner::TimeSeriesOwners,
-    forecast::Forecast,
-    start_time::Union{Nothing, Dates.DateTime} = nothing;
+    forecast::Forecast;
+    start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
 )
     return TimeSeries.timestamp(
@@ -432,8 +432,8 @@ See also: [`get_time_series_array`](@ref get_time_series_array(
 """
 function get_time_series_timestamps(
     owner::TimeSeriesOwners,
-    time_series::StaticTimeSeries,
-    start_time::Union{Nothing, Dates.DateTime} = nothing;
+    time_series::StaticTimeSeries;
+    start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
 )
     return TimeSeries.timestamp(
@@ -571,8 +571,8 @@ See also: [`get_time_series_array`](@ref get_time_series_array(
 """
 function get_time_series_values(
     owner::TimeSeriesOwners,
-    time_series::StaticTimeSeries,
-    start_time::Union{Nothing, Dates.DateTime} = nothing;
+    time_series::StaticTimeSeries;
+    start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
     ignore_scaling_factors = false,
 )

--- a/src/utils/logging.jl
+++ b/src/utils/logging.jl
@@ -330,7 +330,7 @@ end
 """
 function open_file_logger(
     func::Function,
-    filename::String,
+    filename::String;
     level = Logging.Info,
     mode = "w+",
 )

--- a/src/utils/recorder_events.jl
+++ b/src/utils/recorder_events.jl
@@ -165,7 +165,7 @@ Return the events of type T in filename.
 """
 function list_recorder_events(
     ::Type{T},
-    filename::AbstractString,
+    filename::AbstractString;
     filter_func::Union{Nothing, Function} = nothing,
 ) where {T <: AbstractRecorderEvent}
     events = Vector{T}()
@@ -211,8 +211,8 @@ show_recorder_events(TestEvent, test_recorder.log, x -> x.val2 > 2)
 """
 function show_recorder_events(
     ::Type{T},
-    filename::AbstractString,
-    filter_func::Union{Nothing, Function} = nothing;
+    filename::AbstractString;
+    filter_func::Union{Nothing, Function} = nothing,
     kwargs...,
 ) where {T <: AbstractRecorderEvent}
     return show_recorder_events(stdout, T, filename, filter_func; kwargs...)
@@ -221,8 +221,8 @@ end
 function show_recorder_events(
     io::IO,
     ::Type{T},
-    filename::AbstractString,
-    filter_func::Union{Nothing, Function} = nothing;
+    filename::AbstractString;
+    filter_func::Union{Nothing, Function} = nothing,
     kwargs...,
 ) where {T <: AbstractRecorderEvent}
     events = list_recorder_events(T, filename, filter_func)

--- a/test/InfrastructureSystemsTests.jl
+++ b/test/InfrastructureSystemsTests.jl
@@ -61,7 +61,7 @@ function run_tests(args...; kwargs...)
         end
         console_logger = TerminalLogger(config.console_stream, config.console_level)
 
-        IS.open_file_logger(config.filename, config.file_level) do file_logger
+        IS.open_file_logger(config.filename; level = config.file_level) do file_logger
             levels = (Logging.Info, Logging.Warn, Logging.Error)
             multi_logger =
                 IS.MultiLogger([console_logger, file_logger], IS.LogEventTracker(levels))


### PR DESCRIPTION
Missing or incorrect semicolon placement in function definitions was leading to multiple signatures in the documentation

May break calls for these functions:
- `open_file_logger`
- `list_recorder_events`
- `show_recorder_events`
- `get_time_series_multiple`
- `read_time_series`
- `get_time_series`
- `get_time_series_array`
- `get_time_series_timestamps`
- `get_time_series_values`