### PR TITLE
Fix printing of supplemental attributes

### DIFF
--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -113,7 +113,7 @@ function Base.show(io::IO, ::MIME"text/plain", system_units::SystemUnitsSettings
     end
 end
 
-function Base.show(io::IO, ::MIME"text/plain", ist::InfrastructureSystemsComponent)
+function Base.show(io::IO, ::MIME"text/plain", ist::TimeSeriesOwners)
     print(io, summary(ist), ":")
     for name in fieldnames(typeof(ist))
         obj = getfield(ist, name)
@@ -131,7 +131,7 @@ function Base.show(io::IO, ::MIME"text/plain", ist::InfrastructureSystemsCompone
     print(io, "\n   ", "has_time_series", ": ", string(has_time_series(ist)))
 end
 
-function Base.show(io::IO, ist::InfrastructureSystemsComponent)
+function Base.show(io::IO, ist::TimeSeriesOwners)
     print(io, strip_module_name(typeof(ist)), "(")
     is_first = true
     for (name, field_type) in zip(fieldnames(typeof(ist)), fieldtypes(typeof(ist)))


### PR DESCRIPTION
The default Base.show method was printing circular references to objects internal to supplemental attributes. This solution uses the same method as is used for components.