### PR TITLE
Resolve `IS` prefix in submodules (fixes #398)

### DIFF
--- a/src/Optimization/Optimization.jl
+++ b/src/Optimization/Optimization.jl
@@ -10,6 +10,9 @@ import Dates
 import CSV
 import DataFrames
 
+import ..InfrastructureSystems
+const IS = InfrastructureSystems
+
 import ..InfrastructureSystems:
     @scoped_enum,
     InfrastructureSystemsType,

--- a/src/Optimization/optimization_problem_results.jl
+++ b/src/Optimization/optimization_problem_results.jl
@@ -178,7 +178,7 @@ end
 function _validate_keys(existing_keys, result_keys)
     diff = setdiff(result_keys, existing_keys)
     if !isempty(diff)
-        throw(IS.InvalidValue("These keys are not stored: $diff"))
+        throw(InvalidValue("These keys are not stored: $diff"))
     end
     return
 end

--- a/src/Optimization/optimization_test_utils.jl
+++ b/src/Optimization/optimization_test_utils.jl
@@ -69,7 +69,7 @@ function write_optimizer_stats!(
 end
 
 function read_optimizer_stats(store::MockModelStore)
-    stats = [IS.to_namedtuple(x) for x in values(store.optimizer_stats)]
+    stats = [to_namedtuple(x) for x in values(store.optimizer_stats)]
     df = DataFrames.DataFrame(stats)
     DataFrames.insertcols!(df, 1, :DateTime => keys(store.optimizer_stats))
     return df

--- a/src/Simulation/Simulation.jl
+++ b/src/Simulation/Simulation.jl
@@ -3,6 +3,9 @@
 """
 module Simulation
 
+import ..InfrastructureSystems
+const IS = InfrastructureSystems
+
 import ..InfrastructureSystems:
     @scoped_enum
 


### PR DESCRIPTION
Pretty straightforward: I removed the `IS` prefix in submodules where it was not necessary and added `IS` aliases in each submodule for the cases where it is necessary. Right now there are no references to `IS` in `IS.Simulation` but I think it's probably a good practice to have the alias for the future anyway. Fixes https://github.com/NREL-Sienna/InfrastructureSystems.jl/issues/398.