### PR TITLE
Fix performance issue with reading time series

### DIFF
--- a/src/single_time_series.jl
+++ b/src/single_time_series.jl
@@ -44,7 +44,7 @@ function SingleTimeSeries(;
     return SingleTimeSeries(
         name,
         data,
-        _get_resolution(data),
+        get_resolution(data),
         scaling_factor_multiplier,
         internal,
     )
@@ -70,17 +70,6 @@ function SingleTimeSeries(
         scaling_factor_multiplier,
         internal,
     )
-end
-
-function _get_resolution(data::TimeSeries.TimeArray)
-    if length(data) < 2
-        throw(
-            ConflictingInputsError(
-                "Resolution can't be inferred from the data. Please select an appropiate constructor.",
-            ),
-        )
-    end
-    return TimeSeries.timestamp(data)[2] - TimeSeries.timestamp(data)[1]
 end
 
 """

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -385,11 +385,18 @@ end
 Return the resolution from a TimeArray.
 """
 function get_resolution(ts::TimeSeries.TimeArray)
+    if length(ts) < 2
+        throw(ConflictingInputsError("Resolution can't be inferred from the data."))
+    end
+
+    timestamps = TimeSeries.timestamp(ts)
+    return timestamps[2] - timestamps[1]
+end
+
+function check_resolution(ts::TimeSeries.TimeArray)
     tstamps = TimeSeries.timestamp(ts)
     timediffs = unique([tstamps[ix] - tstamps[ix - 1] for ix in 2:length(tstamps)])
-
     res = []
-
     for timediff in timediffs
         if mod(timediff, Dates.Millisecond(Dates.Day(1))) == Dates.Millisecond(0)
             push!(res, Dates.Day(timediff / Dates.Millisecond(Dates.Day(1))))

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -53,3 +53,22 @@ IS.get_name(::FakeTimeSeries) = "fake"
         sprint(show, MIME("text/plain"), summary(FakeTimeSeries())),
     )
 end
+
+@testset "Test check_resolution" begin
+    initial_time1 = Dates.DateTime("2020-09-01")
+    len1 = 24
+    resolution1 = Dates.Hour(1)
+    timestamps1 = range(initial_time1; length = len1, step = resolution1)
+    ta1 = TimeSeries.TimeArray(timestamps1, rand(len1))
+    IS.check_resolution(ta1) == resolution1
+
+    initial_time2 = Dates.DateTime("2020-09-02")
+    len2 = 12
+    resolution2 = Dates.Minute(5)
+    timestamps2 = range(initial_time2; length = len2, step = resolution2)
+    ta2 = TimeSeries.TimeArray(timestamps2, rand(len2))
+    IS.check_resolution(ta2) == resolution2
+
+    ta3 = vcat(ta1, ta2)
+    @test_throws IS.DataFormatError IS.check_resolution(ta3)
+end


### PR DESCRIPTION
Three problems are exposed by #409:
- PowerSimulations was retrieving time series UUIDs through calls to the InfrastructureSystems database when those UUIDs were already cached. That is addressed in https://github.com/NREL-Sienna/PowerSimulations.jl/pull/1169
- The issue above showed that calls to Base.root_module during deserialization are too slow. This PR caches values to avoid unnecessary latency.
- Reading SingleTimeSeries arrays was unnecessarily checking for consistent resolution. That is already checked when the arrays are added to the system. This PR removes those unnecessary checks.

There are still some performance issues related to retrieval of time series metadata that will be fixed in future work.