### PR TITLE
Faster dependencies cache

### DIFF
--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -273,9 +273,7 @@ deserialize(::Type{Vector{Symbol}}, data::Vector) = Symbol.(data)
 
 function serialize_julia_info()
     data = Dict{String, Any}("julia_version" => string(VERSION))
-    io = IOBuffer()
-    Pkg.status(; io = io, mode = Pkg.PKGMODE_MANIFEST)
-    data["package_info"] = String(take!(io))
+    data["package_info"] = Pkg.dependencies()
     return data
 end
 


### PR DESCRIPTION
The previous version can be responsible for a large overhead.

In the figure, the bottom is before the change, and the top is after it.
`serialize_problem` basically disappears.
![image](https://github.com/user-attachments/assets/29a8c675-41ce-46f8-aca7-baa12ceab6cc)
