### PR TITLE
Ensure that a component cannot be added to two systems

### DIFF
--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -401,6 +401,7 @@ function _handle_component_removal!(data::SystemData, component)
 
     pop!(data.component_uuids, uuid)
     remove_component_from_subsystems!(data, component)
+    set_shared_system_references!(component, nothing)
     return
 end
 
@@ -413,6 +414,7 @@ function mask_component!(
     remove_time_series = false,
 )
     remove_component!(data.components, component; remove_time_series = remove_time_series)
+    _handle_component_removal!(data, component)
     return add_masked_component!(
         data,
         component;

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -913,7 +913,7 @@ end
 # Redirect functions to Components
 
 function add_component!(data::SystemData, component; kwargs...)
-    _check_duplicate_component_uuid(data, component)
+    _check_add_component(data, component)
     add_component!(data.components, component; kwargs...)
     data.component_uuids[get_uuid(component)] = component
     refs = SharedSystemReferences(;
@@ -925,6 +925,7 @@ function add_component!(data::SystemData, component; kwargs...)
 end
 
 function add_masked_component!(data::SystemData, component; kwargs...)
+    _check_add_component(data, component)
     add_component!(
         data.masked_components,
         component;
@@ -944,6 +945,13 @@ function remove_masked_component!(data::SystemData, component)
     component = remove_component!(data.masked_components, component)
     _handle_component_removal!(data, component)
     return component
+end
+
+function _check_add_component(data::SystemData, component)
+    _check_duplicate_component_uuid(data, component)
+    if !isnothing(get_shared_system_references(component))
+        error("$(summary(component)) is already attached to a system")
+    end
 end
 
 function _check_duplicate_component_uuid(data::SystemData, component)

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -934,6 +934,8 @@ set_shared_system_references!(
 ) =
     set_shared_system_references!(get_internal(owner), refs)
 
+get_shared_system_references(o::TimeSeriesOwners) = o.internal.shared_system_references
+
 function throw_if_does_not_support_time_series(owner::TimeSeriesOwners)
     if !supports_time_series(owner)
         throw(ArgumentError("$(summary(owner)) does not support time series"))

--- a/test/test_system_data.jl
+++ b/test/test_system_data.jl
@@ -678,3 +678,12 @@ end
         )
     end
 end
+
+@testset "Test component added to two systems" begin
+    sys1 = IS.SystemData()
+    sys2 = IS.SystemData()
+    name = "component"
+    component = IS.TestComponent(name, 1)
+    IS.add_component!(sys1, component)
+    @test_throws ErrorException IS.add_component!(sys2, component)
+end


### PR DESCRIPTION
We used to have a check like this. I discovered today that we currently don't and am restoring it. It's possible that this change will cause a problem for user scripts, but this is definitely a bug. If the user is adding a component to a second system, the first system is now inconsistent.