### PR TITLE
Fix the type of horizon_ms in the time series metadata database

### DIFF
--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -3149,3 +3149,29 @@ end
         normalization_factor = 0.0,
     )
 end
+
+@testset "Test horizon_ms bug fix" begin
+    db = SQLite.DB()
+    tbl = IS.ASSOCIATIONS_TABLE_NAME
+    horizon = Dates.Millisecond(Dates.Hour(1))
+    SQLite.DBInterface.execute(
+        db,
+        "CREATE TABLE $tbl (id INTEGER PRIMARY KEY, horizon_ms INTEGER)",
+    )
+    SQLite.transaction(db) do
+        SQLite.DBInterface.execute(db, "INSERT INTO $tbl VALUES(?,?)", (missing, missing))
+        SQLite.DBInterface.execute(db, "INSERT INTO $tbl VALUES(?,?)", (missing, horizon))
+        SQLite.DBInterface.execute(db, "INSERT INTO $tbl VALUES(?,?)", (missing, horizon))
+    end
+    table =
+        Tables.columntable(SQLite.DBInterface.execute(db, "SELECT horizon_ms FROM $tbl"))
+    @test ismissing(table.horizon_ms[1])
+    @test table.horizon_ms[2] isa Dates.Millisecond
+    @test table.horizon_ms[3] isa Dates.Millisecond
+    IS._apply_horizon_type_fix_if_needed(db)
+    table2 =
+        Tables.columntable(SQLite.DBInterface.execute(db, "SELECT horizon_ms FROM $tbl"))
+    @test ismissing(table.horizon_ms[1])
+    @test table2.horizon_ms[2] == horizon.value
+    @test table2.horizon_ms[3] == horizon.value
+end


### PR DESCRIPTION
The code was mistakenly writing `horizon_ms` as a serialized `Dates.Millisecond` object instead of an integer. This PR fixes the database during deserialization.

Bug introduction: when we converted horizon from an integer to a period on 2024-05-13.

Impact of the bug: usually, none. However, there was one case this week where a user had a custom environment and adding  a row to the db failed because of what was likely a different in the version of the Dates package.