### PR TITLE
Update OptimizationResults to use `Vector{DateTime}`

### DIFF
--- a/src/Optimization/optimization_problem_results.jl
+++ b/src/Optimization/optimization_problem_results.jl
@@ -17,20 +17,20 @@ mutable struct OptimizationProblemResults <: Results
 end
 
 function OptimizationProblemResults(
-    base_power::Float64,
+    base_power,
     timestamps::StepRange{Dates.DateTime, Dates.Millisecond},
-    source_data::Union{Nothing, InfrastructureSystemsType},
-    source_data_uuid::Base.UUID,
-    aux_variable_values::Dict{AuxVarKey, DataFrames.DataFrame},
-    variable_values::Dict{VariableKey, DataFrames.DataFrame},
-    dual_values::Dict{ConstraintKey, DataFrames.DataFrame},
-    parameter_values::Dict{ParameterKey, DataFrames.DataFrame},
-    expression_values::Dict{ExpressionKey, DataFrames.DataFrame},
-    optimizer_stats::DataFrames.DataFrame,
-    optimization_container_metadata::OptimizationContainerMetadata,
-    model_type::String,
-    results_dir::String,
-    output_dir::String,
+    source_data,
+    source_data_uuid,
+    aux_variable_values,
+    variable_values,
+    dual_values,
+    parameter_values,
+    expression_values,
+    optimizer_stats,
+    optimization_container_metadata,
+    model_type,
+    results_dir,
+    output_dir,
 )
     return OptimizationProblemResults(
         base_power,

--- a/src/Optimization/optimization_problem_results.jl
+++ b/src/Optimization/optimization_problem_results.jl
@@ -75,7 +75,6 @@ get_aux_variable_values(res::OptimizationProblemResults) = res.aux_variable_valu
 get_total_cost(res::OptimizationProblemResults) = get_objective_value(res)
 get_optimizer_stats(res::OptimizationProblemResults) = res.optimizer_stats
 get_parameter_values(res::OptimizationProblemResults) = res.parameter_values
-get_resolution(res::OptimizationProblemResults) = res.timestamps.step
 get_source_data(res::OptimizationProblemResults) = res.source_data
 get_forecast_horizon(res::OptimizationProblemResults) = length(get_timestamps(res))
 get_output_dir(res::OptimizationProblemResults) = res.output_dir
@@ -90,6 +89,16 @@ get_result_values(x::OptimizationProblemResults, ::VariableKey) = x.variable_val
 
 function get_objective_value(res::OptimizationProblemResults, execution = 1)
     return res.optimizer_stats[execution, :objective_value]
+end
+
+function get_resolution(res::OptimizationProblemResults)
+    # Method return the first resolution between timestamps
+    # If single timestamp is used, it return nothing
+    diff_res = diff(get_timestamps(res))
+    if !isempty(diff_res)
+        return first(diff_res)
+    end
+    return nothing
 end
 
 function export_result(

--- a/src/Optimization/optimization_problem_results.jl
+++ b/src/Optimization/optimization_problem_results.jl
@@ -16,6 +16,40 @@ mutable struct OptimizationProblemResults <: Results
     output_dir::String
 end
 
+function OptimizationProblemResults(
+    base_power::Float64,
+    timestamps::StepRange{Dates.DateTime, Dates.Millisecond},
+    source_data::Union{Nothing, InfrastructureSystemsType},
+    source_data_uuid::Base.UUID,
+    aux_variable_values::Dict{AuxVarKey, DataFrames.DataFrame},
+    variable_values::Dict{VariableKey, DataFrames.DataFrame},
+    dual_values::Dict{ConstraintKey, DataFrames.DataFrame},
+    parameter_values::Dict{ParameterKey, DataFrames.DataFrame},
+    expression_values::Dict{ExpressionKey, DataFrames.DataFrame},
+    optimizer_stats::DataFrames.DataFrame,
+    optimization_container_metadata::OptimizationContainerMetadata,
+    model_type::String,
+    results_dir::String,
+    output_dir::String,
+)
+    return OptimizationProblemResults(
+        base_power,
+        collect(timestamps),
+        source_data,
+        source_data_uuid,
+        aux_variable_values,
+        variable_values,
+        dual_values,
+        parameter_values,
+        expression_values,
+        optimizer_stats,
+        optimization_container_metadata,
+        model_type,
+        results_dir,
+        output_dir,
+    )
+end
+
 list_aux_variable_keys(res::OptimizationProblemResults) =
     collect(keys(res.aux_variable_values))
 list_aux_variable_names(res::OptimizationProblemResults) =

--- a/src/Optimization/optimization_problem_results.jl
+++ b/src/Optimization/optimization_problem_results.jl
@@ -1,7 +1,7 @@
 # This needs renaming to avoid collision with the DecisionModelResults/EmulationModelResults
 mutable struct OptimizationProblemResults <: Results
     base_power::Float64
-    timestamps::StepRange{Dates.DateTime, Dates.Millisecond}
+    timestamps::Vector{Dates.DateTime}
     source_data::Union{Nothing, InfrastructureSystemsType}
     source_data_uuid::Base.UUID
     aux_variable_values::Dict{AuxVarKey, DataFrames.DataFrame}
@@ -276,13 +276,27 @@ function _read_results(
                         v
                     end
             else
-                results[k] =
-                    if convert_result_to_natural_units(k)
-                        v[time_ids, :] .* base_power
-                    else
-                        v[time_ids, :]
-                    end
-                DataFrames.insertcols!(results[k], 1, :DateTime => timestamps)
+                total_rows = size(v)[1]
+                if total_rows == length(time_ids)
+                    results[k] =
+                        if convert_result_to_natural_units(k)
+                            v[time_ids, :] .* base_power
+                        else
+                            v[time_ids, :]
+                        end
+                    DataFrames.insertcols!(results[k], 1, :DateTime => timestamps)
+                else
+                    @warn(
+                        "Length of variables is different than timestamps. Ignoring timestamps."
+                    )
+                    results[k] =
+                        if convert_result_to_natural_units(k)
+                            v[1:total_rows, :] .* base_power
+                        else
+                            v[1:total_rows, :]
+                        end
+                    DataFrames.insertcols!(results[k], 1)
+                end
             end
         end
     end

--- a/src/Optimization/optimization_problem_results.jl
+++ b/src/Optimization/optimization_problem_results.jl
@@ -92,11 +92,18 @@ function get_objective_value(res::OptimizationProblemResults, execution = 1)
 end
 
 function get_resolution(res::OptimizationProblemResults)
-    # Method return the first resolution between timestamps
-    # If single timestamp is used, it return nothing
+    # Method return the resolution between timestamps.
+    # If multiple resolutions are present it returns the first observed.
+    # If single timestamp is used, it return nothing.
     diff_res = diff(get_timestamps(res))
     if !isempty(diff_res)
-        return first(diff_res)
+        unique!(diff_res)
+        if length(diff_res) == 1
+            return only(diff_res)
+        else
+            @warn "Multiple resolutions detected, returning the first resolution."
+            return first(diff_res)
+        end
     end
     return nothing
 end

--- a/test/test_optimization_results.jl
+++ b/test/test_optimization_results.jl
@@ -14,7 +14,11 @@ const IS = InfrastructureSystems
     base_power = 1.0
     # 2 hours timestamp range
     timestamp_range =
-        StepRange(DateTime("2024-01-01T00:00:00"), Hour(1), DateTime("2024-01-01T01:00:00"))
+        StepRange(
+            DateTime("2024-01-01T00:00:00"),
+            Millisecond(3600000),
+            DateTime("2024-01-01T01:00:00"),
+        )
     timestamp_vec = collect(timestamp_range)
     data = IS.SystemData()
     uuid = IS.make_uuid()

--- a/test/test_optimization_results.jl
+++ b/test/test_optimization_results.jl
@@ -1,13 +1,8 @@
 import InfrastructureSystems.Optimization:
-    OptimizerStats,
     OptimizationContainerMetadata,
     OptimizationProblemResults,
     VariableKey,
-    ConstraintKey,
-    AuxVarKey,
     ExpressionKey,
-    ParameterKey,
-    InitialConditionKey,
     read_variable,
     read_expression
 import Dates:

--- a/test/test_optimization_results.jl
+++ b/test/test_optimization_results.jl
@@ -64,7 +64,7 @@ const IS = InfrastructureSystems
     )
     # Check that variable has time series
     var_res = read_variable(opt_res1, var_key)
-    @test size(read_variable(opt_res1, var_key)) == (2, 2)
+    @test size(var_res) == (2, 2)
     @test length(var_res[!, "DateTime"]) == 2
     # Check that expression only has a single column
     @test size(read_expression(opt_res2, exp_key)) == (1, 1)

--- a/test/test_optimization_results.jl
+++ b/test/test_optimization_results.jl
@@ -3,8 +3,11 @@ import InfrastructureSystems.Optimization:
     OptimizationProblemResults,
     VariableKey,
     ExpressionKey,
+    MockVariable,
+    MockExpression,
     read_variable,
-    read_expression
+    read_expression,
+    convert_result_to_natural_units
 import Dates:
     DateTime,
     Millisecond
@@ -23,11 +26,11 @@ const IS = InfrastructureSystems
     data = IS.SystemData()
     uuid = IS.make_uuid()
     aux_variable_values = Dict()
-    var_key = VariableKey(IS.Optimization.MockVariable, IS.TestComponent)
+    var_key = VariableKey(MockVariable, IS.TestComponent)
     variable_values = Dict(var_key => DataFrame(["test" => [1.0, 2.0]]))
     dual_values = Dict()
     parameter_values = Dict()
-    exp_key = ExpressionKey(IS.Optimization.MockExpression, IS.TestComponent)
+    exp_key = ExpressionKey(MockExpression, IS.TestComponent)
     # Expression only 1 time-step
     expression_values = Dict(exp_key => DataFrame(["test2" => 1.0]))
     optimizer_stats = DataFrames.DataFrame()
@@ -71,14 +74,14 @@ const IS = InfrastructureSystems
     @test size(var_res) == (2, 2)
     @test length(var_res[!, "DateTime"]) == 2
     @test [1.0, 2.0] == var_res[!, 2]
-    IS.Optimization.convert_result_to_natural_units(::Type{<:IS.Optimization.MockVariable}) = true
+    convert_result_to_natural_units(::Type{<:MockVariable}) = true
     var_res = IS.Optimization.read_variable(opt_res1, var_key)
     @test var_res[!, 2] == [10.0, 20.0]
     # Check that expression only has a single column
     exp_res = read_expression(opt_res2, exp_key)
     @test size(exp_res) == (1, 1)
     @test exp_res[!, 1] == 1.0
-    IS.Optimization.convert_result_to_natural_units(::Type{<:IS.Optimization.MockExpression}) = true
+    convert_result_to_natural_units(::Type{<:MockExpression}) = true
     exp_res = read_expression(opt_res2, exp_key)
     @test exp_res[!, 1] == 10.0
 end

--- a/test/test_optimization_results.jl
+++ b/test/test_optimization_results.jl
@@ -11,7 +11,7 @@ import Dates:
 const IS = InfrastructureSystems
 
 @testset "Test OptimizationProblemResults" begin
-    base_power = 1.0
+    base_power = 10.0
     # 2 hours timestamp range
     timestamp_range =
         StepRange(
@@ -24,17 +24,17 @@ const IS = InfrastructureSystems
     uuid = IS.make_uuid()
     aux_variable_values = Dict()
     var_key = VariableKey(IS.Optimization.MockVariable, IS.TestComponent)
-    variable_values = Dict(var_key => DataFrame(["test" => 1:2]))
+    variable_values = Dict(var_key => DataFrame(["test" => [1.0, 2.0]]))
     dual_values = Dict()
     parameter_values = Dict()
     exp_key = ExpressionKey(IS.Optimization.MockExpression, IS.TestComponent)
     # Expression only 1 time-step
-    expression_values = Dict(exp_key => DataFrame(["test2" => 1]))
+    expression_values = Dict(exp_key => DataFrame(["test2" => 1.0]))
     optimizer_stats = DataFrames.DataFrame()
     metadata = OptimizationContainerMetadata()
     # Test with StepRange
     opt_res1 = OptimizationProblemResults(
-        1.0,
+        base_power,
         timestamp_range,
         data,
         uuid,
@@ -51,7 +51,7 @@ const IS = InfrastructureSystems
     )
     # Test with Vector{DateTime}
     opt_res2 = OptimizationProblemResults(
-        1.0,
+        base_power,
         timestamp_vec,
         data,
         uuid,
@@ -70,6 +70,15 @@ const IS = InfrastructureSystems
     var_res = read_variable(opt_res1, var_key)
     @test size(var_res) == (2, 2)
     @test length(var_res[!, "DateTime"]) == 2
+    @test [1.0, 2.0] == var_res[!, 2]
+    IS.Optimization.convert_result_to_natural_units(::Type{<:IS.Optimization.MockVariable}) = true
+    var_res = IS.Optimization.read_variable(opt_res1, var_key)
+    @test var_res[!, 2] == [10.0, 20.0]
     # Check that expression only has a single column
-    @test size(read_expression(opt_res2, exp_key)) == (1, 1)
+    exp_res = read_expression(opt_res2, exp_key)
+    @test size(exp_res) == (1, 1)
+    @test exp_res[!, 1] == 1.0
+    IS.Optimization.convert_result_to_natural_units(::Type{<:IS.Optimization.MockExpression}) = true
+    exp_res = read_expression(opt_res2, exp_key)
+    @test exp_res[!, 1] == 10.0
 end

--- a/test/test_optimization_results.jl
+++ b/test/test_optimization_results.jl
@@ -6,8 +6,7 @@ import InfrastructureSystems.Optimization:
     MockVariable,
     MockExpression,
     read_variable,
-    read_expression,
-    convert_result_to_natural_units
+    read_expression
 import Dates:
     DateTime,
     Millisecond
@@ -74,14 +73,16 @@ const IS = InfrastructureSystems
     @test size(var_res) == (2, 2)
     @test length(var_res[!, "DateTime"]) == 2
     @test [1.0, 2.0] == var_res[!, 2]
-    convert_result_to_natural_units(::Type{<:MockVariable}) = true
+    # Check base power transformation
+    IS.Optimization.convert_result_to_natural_units(::Type{<:MockVariable}) = true
     var_res = IS.Optimization.read_variable(opt_res1, var_key)
     @test var_res[!, 2] == [10.0, 20.0]
     # Check that expression only has a single column
     exp_res = read_expression(opt_res2, exp_key)
     @test size(exp_res) == (1, 1)
-    @test exp_res[!, 1] == 1.0
-    convert_result_to_natural_units(::Type{<:MockExpression}) = true
+    @test exp_res[!, 1] == [1.0]
+    # Check base power transformation
+    IS.Optimization.convert_result_to_natural_units(::Type{<:MockExpression}) = true
     exp_res = read_expression(opt_res2, exp_key)
-    @test exp_res[!, 1] == 10.0
+    @test exp_res[!, 1] == [10.0]
 end

--- a/test/test_optimization_results.jl
+++ b/test/test_optimization_results.jl
@@ -68,6 +68,24 @@ const IS = InfrastructureSystems
         mktempdir(),
         mktempdir(),
     )
+    timestamp_vec2 = deepcopy(timestamp_vec)
+    pop!(timestamp_vec2)
+    opt_res3 = OptimizationProblemResults(
+        base_power,
+        timestamp_vec2,
+        data,
+        uuid,
+        aux_variable_values,
+        variable_values,
+        dual_values,
+        parameter_values,
+        expression_values,
+        optimizer_stats,
+        metadata,
+        "test_model",
+        mktempdir(),
+        mktempdir(),
+    )
     # Check that variable has time series
     var_res = read_variable(opt_res1, var_key)
     @test size(var_res) == (2, 2)
@@ -85,4 +103,8 @@ const IS = InfrastructureSystems
     IS.Optimization.convert_result_to_natural_units(::Type{<:MockExpression}) = true
     exp_res = read_expression(opt_res2, exp_key)
     @test exp_res[!, 1] == [10.0]
+    # Test resolutions
+    @test IS.Optimization.get_resolution(opt_res1) == Millisecond(3600000)
+    @test IS.Optimization.get_resolution(opt_res2) == Millisecond(3600000)
+    @test isnothing(IS.Optimization.get_resolution(opt_res3))
 end

--- a/test/test_optimization_results.jl
+++ b/test/test_optimization_results.jl
@@ -7,7 +7,7 @@ import InfrastructureSystems.Optimization:
     read_expression
 import Dates:
     DateTime,
-    Hour
+    Millisecond
 const IS = InfrastructureSystems
 
 @testset "Test OptimizationProblemResults" begin

--- a/test/test_optimization_results.jl
+++ b/test/test_optimization_results.jl
@@ -1,0 +1,76 @@
+import InfrastructureSystems.Optimization:
+    OptimizerStats,
+    OptimizationContainerMetadata,
+    OptimizationProblemResults,
+    VariableKey,
+    ConstraintKey,
+    AuxVarKey,
+    ExpressionKey,
+    ParameterKey,
+    InitialConditionKey,
+    read_variable,
+    read_expression
+import Dates:
+    DateTime,
+    Hour
+const IS = InfrastructureSystems
+
+@testset "Test OptimizationProblemResults" begin
+    base_power = 1.0
+    # 2 hours timestamp range
+    timestamp_range =
+        StepRange(DateTime("2024-01-01T00:00:00"), Hour(1), DateTime("2024-01-01T01:00:00"))
+    timestamp_vec = collect(timestamp_range)
+    data = IS.SystemData()
+    uuid = IS.make_uuid()
+    aux_variable_values = Dict()
+    var_key = VariableKey(IS.Optimization.MockVariable, IS.TestComponent)
+    variable_values = Dict(var_key => DataFrame(["test" => 1:2]))
+    dual_values = Dict()
+    parameter_values = Dict()
+    exp_key = ExpressionKey(IS.Optimization.MockExpression, IS.TestComponent)
+    # Expression only 1 time-step
+    expression_values = Dict(exp_key => DataFrame(["test2" => 1]))
+    optimizer_stats = DataFrames.DataFrame()
+    metadata = OptimizationContainerMetadata()
+    # Test with StepRange
+    opt_res1 = OptimizationProblemResults(
+        1.0,
+        timestamp_range,
+        data,
+        uuid,
+        aux_variable_values,
+        variable_values,
+        dual_values,
+        parameter_values,
+        expression_values,
+        optimizer_stats,
+        metadata,
+        "test_model",
+        mktempdir(),
+        mktempdir(),
+    )
+    # Test with Vector{DateTime}
+    opt_res2 = OptimizationProblemResults(
+        1.0,
+        timestamp_vec,
+        data,
+        uuid,
+        aux_variable_values,
+        variable_values,
+        dual_values,
+        parameter_values,
+        expression_values,
+        optimizer_stats,
+        metadata,
+        "test_model",
+        mktempdir(),
+        mktempdir(),
+    )
+    # Check that variable has time series
+    var_res = read_variable(opt_res1, var_key)
+    @test size(read_variable(opt_res1, var_key)) == (2, 2)
+    @test length(var_res[!, "DateTime"]) == 2
+    # Check that expression only has a single column
+    @test size(read_expression(opt_res2, exp_key)) == (1, 1)
+end


### PR DESCRIPTION
New version for #415 as rebasing was a mess.

- Added a test that check that using the previous StepRange works fine, as it does the conversion automatically.
- Also added code that still output the result if the length is different than timesteps. Give a warning when that happens. The test also check that timestamps are ignored in that case.