### PR TITLE
Complete `ComponentSelector` docstrings

### DIFF
--- a/src/InfrastructureSystems.jl
+++ b/src/InfrastructureSystems.jl
@@ -72,7 +72,7 @@ Optional interface functions:
 
 Subtypes may contain time series. Which requires
 
-  - supports_time_series(::SupplementalAttribute)
+  - `supports_time_series(::SupplementalAttribute)`
 
 All subtypes must include an instance of ComponentUUIDs in order to track
 components attached to each attribute.

--- a/src/common.jl
+++ b/src/common.jl
@@ -41,7 +41,7 @@ const CONSTANT = Float64
 const LIM_TOL = 1e-6
 const XY_COORDS = @NamedTuple{x::Float64, y::Float64}
 
-"Delimiter to use when constructing qualified names like component_type__component_name."
+"Delimiter to use when constructing qualified names like `component_type__component_name`."
 const COMPONENT_NAME_DELIMITER = "__"
 
 # See https://github.com/JuliaLang/julia/issues/18485

--- a/src/component_container.jl
+++ b/src/component_container.jl
@@ -1,4 +1,15 @@
-"A data structure that acts like a container of components"
+"""
+A data structure that acts like a container of components. The `ComponentContainer`
+interface consists of:
+  - `get_components`
+  - `get_component`
+  - `get_available(::ComponentContainer, ::InfrastructureSystemsComponent)`
+  - `get_available_components`
+  - `get_available_component`
+
+Notable subtypes include [`Components`](@ref), [`SystemData`](@ref), and
+[`PowerSystems.System`](@extref).
+"""
 abstract type ComponentContainer <: InfrastructureSystemsContainer end
 
 # For each of these functions, `ComponentContainer` concrete subtypes MUST either implement

--- a/src/component_container.jl
+++ b/src/component_container.jl
@@ -20,10 +20,10 @@ function get_component end
 "Get whether the given component of the given system is available for use (defaults to true)."
 get_available(::ComponentContainer, ::InfrastructureSystemsComponent) = true
 
-"Like [`get_components`](@ref) but only on components that are available."
+"Like `get_components` but only on components that are available."
 function get_available_components end
 
-"Like [`get_component`](@ref) but only on components that are available."
+"Like `get_component` but only on components that are available."
 function get_available_component end
 
 get_available_components(sys::ComponentContainer, args...; kwargs...) =

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -18,6 +18,8 @@ New system-like types MUST ensure that `get_available_components` and `get_avail
 work for them.
 =#
 
+# NOTE we cannot do all the @ref links we want to here because `IS.get_components !== PSY.get_components`, etc.
+# See https://github.com/NREL-Sienna/InfrastructureSystems.jl/issues/388#issuecomment-2660019861
 """
 The base type for all `ComponentSelector`s.
 
@@ -26,26 +28,26 @@ collections of `InfrastructureSystemsComponent`s.
 
 # Core Interface
 
-  - [`make_selector`](@ref): factory function to handle `ComponentSelector` creation; end
+  - `make_selector`: factory function to handle `ComponentSelector` creation; end
     users should use this rather than calling the constructors directly.
-  - [`get_groups`](@ref): get the groups that make up a `ComponentSelector`, which will
+  - `get_groups`: get the groups that make up a `ComponentSelector`, which will
     themselves be represented as `ComponentSelector`s.
-  - [`get_components`](@ref): get all the components that make up a `ComponentSelector`,
+  - `get_components`: get all the components that make up a `ComponentSelector`,
     ignoring how they are grouped. A component should appear in the `get_components` of a
     given selector if and only if it appears in the `get_components` of at least one of that
     selector's groups.
-  - [`get_name`](@ref): get the name of the `ComponentSelector`. All `ComponentSelector`s
+  - `get_name`: get the name of the `ComponentSelector`. All `ComponentSelector`s
     have a name, whether it is specified by the user or created automatically.
-  - [`rebuild_selector`](@ref): create a new `ComponentSelector` from an existing one with
+  - `rebuild_selector`: create a new `ComponentSelector` from an existing one with
     some details (e.g., the name or the grouping behavior) tweaked.
 
 # Availability Filtering
 
-Besides the core interface, also provided are [`get_component`](@ref) for
+Besides the core interface, also provided are `get_component` for
 `ComponentSelector` subtypes that can only refer to at most one component; and
-[`get_available_component`](@ref), [`get_available_components`](@ref), and
-[`get_available_groups`](@ref), which work the same as the corresponding functions without
-`available` except they only consider components for which [`get_available`](@ref) is true.
+`get_available_component`, `get_available_components`, and
+`get_available_groups`, which work the same as the corresponding functions without
+`available` except they only consider components for which `get_available` is true.
 
 # `scope_limiter` Filtering
 
@@ -67,7 +69,7 @@ The interface is the same as for `ComponentSelector` except:
 =#
 """
 [`ComponentSelector`](@ref) subtype that can only refer to zero or one components.
-[`get_components`](@ref) will always return zero or one components; [`get_component`](@ref)
+`get_components` will always return zero or one components; `get_component`
 will return the component directly if there is one and return `nothing` if there is not.
 """
 abstract type SingularComponentSelector <: ComponentSelector end
@@ -144,14 +146,14 @@ arguments. Users should call this rather than manually constructing `ComponentSe
 # Arguments
 
 Several methods of this function have a parameter `groupby::Union{Symbol, Function}`, which
-specifies how the selector is grouped for the purposes of [`get_groups`](@ref). The
+specifies how the selector is grouped for the purposes of `get_groups`. The
 `groupby` argument has the following semantics:
 
   - `groupby = :each` (default): each component that makes up the selector forms its own
-    group. The number of groups from [`get_groups`](@ref) will be equal to the number of
-    components from [`get_components`](@ref).
+    group. The number of groups from `get_groups` will be equal to the number of
+    components from `get_components`.
   - `groupby = :all`: all components that make up the selector are put into the same group.
-    [`get_groups`](@ref) will yield one group.
+    `get_groups` will yield one group.
   - `groupby = partition_function`: if the argument is a user-supplied function, the
     function will be applied to each component; all components with the same result under
     the function will be grouped together, with the name of the group specified by the
@@ -194,7 +196,7 @@ get_component(selector::SingularComponentSelector, sys) =
     get_component(nothing, selector, sys)
 
 """
-Like [`get_components`](@ref) but only operates on components for which
+Like `get_components` but only operates on components for which
 [`get_available`](@ref) is `true`.
 """
 function get_available_components(
@@ -207,14 +209,14 @@ function get_available_components(
 end
 
 """
-Like [`get_components`](@ref) but only operates on components for which
+Like `get_components` but only operates on components for which
 [`get_available`](@ref) is `true`.
 """
 get_available_components(selector::ComponentSelector, sys) =
     get_available_components(nothing, selector, sys)
 
 """
-Like [`get_component`](@ref) but only operates on components for which
+Like `get_component` but only operates on components for which
 [`get_available`](@ref) is `true`.
 """
 get_available_component(
@@ -224,7 +226,7 @@ get_available_component(
 ) = get_component(available_and_fn(scope_limiter, sys), selector, sys)
 
 """
-Like [`get_component`](@ref) but only operates on components for which
+Like `get_component` but only operates on components for which
 [`get_available`](@ref) is `true`.
 """
 get_available_component(selector::ComponentSelector, sys) =

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -21,8 +21,8 @@ work for them.
 """
 The base type for all `ComponentSelector`s.
 
-Instances of `ComponentSelector` represent named, lazy, grouped collections of
-`InfrastructureSystemsComponent`s.
+Instances of `ComponentSelector` represent lazy, grouped, named, system-independent
+collections of `InfrastructureSystemsComponent`s.
 
 # Core Interface
 
@@ -231,13 +231,13 @@ get_available_component(selector::ComponentSelector, sys) =
     get_available_component(nothing, selector, sys)
 
 """
-Get the groups that make up the `ComponentSelector`, first filtering using the filter
-function `scope_limiter`.
-"""
-function get_groups end
+Given a system-like source of component, get the groups that make up the
+[`ComponentSelector`](@ref).
 
-"""
-Get the groups that make up the `ComponentSelector`.
+# Arguments
+
+  - `selector::ComponentSelector`: the `ComponentSelector` whose groups should be retrieved
+  - `sys`: the system-like source of components to draw from
 """
 get_groups(selector::ComponentSelector, sys) = get_groups(nothing, selector, sys)
 
@@ -269,8 +269,16 @@ function _make_group(all_components, partition_results, group_result, group_name
 end
 
 """
-Use the `groupby` property to get the groups that make up the
-`DynamicallyGroupedComponentSelector`
+Given a system-like source of component, use the `groupby` property (see
+[`make_selector`](@ref)) to get the groups that make up the
+`DynamicallyGroupedComponentSelector`.
+
+# Arguments
+
+  - `scope_limiter::Union{Function, Nothing}`: see [`ComponentSelector`](@ref)
+  - `selector::DynamicallyGroupedComponentSelector`: the
+    `DynamicallyGroupedComponentSelector` whose groups should be retrieved
+  - `sys`: the system-like source of components to draw from
 """
 function get_groups(
     scope_limiter::Union{Function, Nothing},
@@ -297,8 +305,22 @@ function get_groups(
     ]
 end
 
-"Get the single group that corresponds to the `SingularComponentSelector`, i.e., itself"
-get_groups(::Union{Function, Nothing}, selector::SingularComponentSelector, sys) =
+"""
+Get the single group that corresponds to the `SingularComponentSelector`, i.e., itself.
+
+# Arguments
+
+  - `scope_limiter::Union{Function, Nothing}`: see [`ComponentSelector`](@ref) (unused in
+    this case)
+  - `selector::SingularComponentSelector`: the `SingularComponentSelector` whose group
+    should be retrieved
+  - `sys`: the system-like source of components to draw from (unused in this case)
+"""
+get_groups(
+    scope_limiter::Union{Function, Nothing},
+    selector::SingularComponentSelector,
+    sys,
+) =
     [selector]
 
 # Fallback `rebuild_selector` that only handles `name`
@@ -404,6 +426,16 @@ make_selector(
     make_selector(typeof(component), get_name(component)::AbstractString; name = name)
 
 # Contents
+"""
+Get the component to which the `NameComponentSelector` points, or `nothing` if such a
+component does not exist in `sys`.
+
+# Arguments
+
+  - `scope_limiter::Union{Function, Nothing}`: see [`ComponentSelector`](@ref)
+  - `selector::NameComponentSelector`: the `NameComponentSelector` whose component to get
+  - `sys`: the system-like source of components to draw from
+"""
 function get_component(
     scope_limiter::Union{Function, Nothing},
     selector::NameComponentSelector,
@@ -415,6 +447,15 @@ function get_component(
     return com
 end
 
+"""
+Get the components to which the `NameComponentSelector` points.
+
+# Arguments
+
+  - `scope_limiter::Union{Function, Nothing}`: see [`ComponentSelector`](@ref)
+  - `selector::NameComponentSelector`: the `NameComponentSelector` whose components to get
+  - `sys`: the system-like source of components to draw from
+"""
 function get_components(
     scope_limiter::Union{Function, Nothing},
     selector::NameComponentSelector,
@@ -456,11 +497,29 @@ of the selectors they were constructed with.
 make_selector(content::ComponentSelector...; name::Union{String, Nothing} = nothing) =
     ListComponentSelector(content, name)
 
+"""
+Get the groups to which the `ListComponentSelector` points.
+
+# Arguments
+
+  - `scope_limiter::Union{Function, Nothing}`: see [`ComponentSelector`](@ref)
+  - `selector::ListComponentSelector`: the `ListComponentSelector` whose groups to get
+  - `sys`: the system-like source of components to draw from
+"""
 # Contents
 function get_groups(::Union{Function, Nothing}, selector::ListComponentSelector, sys)
     return selector.content
 end
 
+"""
+Get the components to which the `ListComponentSelector` points.
+
+# Arguments
+
+  - `scope_limiter::Union{Function, Nothing}`: see [`ComponentSelector`](@ref)
+  - `selector::ListComponentSelector`: the `ListComponentSelector` whose components to get
+  - `sys`: the system-like source of components to draw from
+"""
 function get_components(
     scope_limiter::Union{Function, Nothing},
     selector::ListComponentSelector,
@@ -548,6 +607,15 @@ make_selector(
 ) = TypeComponentSelector(component_type, groupby, name)
 
 # Contents
+"""
+Get the components to which the `TypeComponentSelector` points.
+
+# Arguments
+
+  - `scope_limiter::Union{Function, Nothing}`: see [`ComponentSelector`](@ref)
+  - `selector::TypeComponentSelector`: the `TypeComponentSelector` whose components to get
+  - `sys`: the system-like source of components to draw from
+"""
 function get_components(
     scope_limiter::Union{Function, Nothing},
     selector::TypeComponentSelector,
@@ -592,12 +660,6 @@ FilterComponentSelector(
     )
 
 """
-Make a ComponentSelector from a filter function and a type of component. The filter function
-must accept instances of `component_type` as a sole argument and return a `Bool`. Optionally
-provide a name and/or grouping behavior for the `ComponentSelector`.
-"""
-
-"""
 Make a [`ComponentSelector`](@ref) from a filter function and a type of component. The
 filter function must accept instances of `component_type` as a sole argument and return a
 `Bool`. Optionally provide a grouping behavior and/or name for the selector. Selectors
@@ -623,6 +685,15 @@ make_selector(
 ) = FilterComponentSelector(component_type, filter_func, groupby, name)
 
 # Contents
+"""
+Get the components to which the `FilterComponentSelector` points.
+
+# Arguments
+
+  - `scope_limiter::Union{Function, Nothing}`: see [`ComponentSelector`](@ref)
+  - `selector::FilterComponentSelector`: the `FilterComponentSelector` whose components to get
+  - `sys`: the system-like source of components to draw from
+"""
 function get_components(
     scope_limiter::Union{Function, Nothing},
     selector::FilterComponentSelector,
@@ -655,6 +726,15 @@ end
 get_name(selector::RegroupedComponentSelector) = get_name(selector.wrapped_selector)
 
 # Contents
+"""
+Get the components to which the `RegroupedComponentSelector` points.
+
+# Arguments
+
+  - `scope_limiter::Union{Function, Nothing}`: see [`ComponentSelector`](@ref)
+  - `selector::RegroupedComponentSelector`: the `RegroupedComponentSelector` whose components to get
+  - `sys`: the system-like source of components to draw from
+"""
 get_components(
     scope_limiter::Union{Function, Nothing},
     selector::RegroupedComponentSelector,

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -21,10 +21,11 @@ work for them.
 # NOTE we cannot do all the @ref links we want to here because `IS.get_components !== PSY.get_components`, etc.
 # See https://github.com/NREL-Sienna/InfrastructureSystems.jl/issues/388#issuecomment-2660019861
 """
-The base type for all `ComponentSelector`s.
-
-Instances of `ComponentSelector` represent lazy, grouped, named, system-independent
-collections of `InfrastructureSystemsComponent`s.
+Given some source of components to draw from, like a system, a `ComponentSelector` picks out
+a certain subset of them based on some user-defined selection criteria. A
+`ComponentSelector` can also be used to name that subset of components or to split it up
+into groups. The same `ComponentSelector` can be used to apply the same set of selection
+criteria to multiple sources of components.
 
 # Core Interface
 

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -424,6 +424,8 @@ it doesn't.
 sel1 = make_selector(ThermalStandard, "322_CT_6")
 sel2 = make_selector(ThermalStandard, "322_CT_6"; name = "my_selector")
 ```
+
+See also: [`make_selector`](@ref) unified function documentation
 """
 make_selector(
     component_type::Type{<:InfrastructureSystemsComponent},
@@ -449,6 +451,8 @@ component exists and zero if it doesn't.
 sel1 = make_selector(my_component)
 sel2 = make_selector(my_component; name = "my_selector")
 ```
+
+See also: [`make_selector`](@ref) unified function documentation
 """
 make_selector(
     component::InfrastructureSystemsComponent;
@@ -531,6 +535,8 @@ of the selectors they were constructed with.
 sel1 = make_selector(make_selector(ThermalStandard), make_selector(RenewableDispatch))
 sel2 = make_selector(make_selector(ThermalStandard), make_selector(RenewableDispatch); name = "my_selector")
 ```
+
+See also: [`make_selector`](@ref) unified function documentation
 """
 make_selector(content::ComponentSelector...; name::Union{String, Nothing} = nothing) =
     ListComponentSelector(content, name)
@@ -645,6 +651,8 @@ sel1 = make_selector(RenewableDispatch)
 sel2 = make_selector(RenewableDispatch; groupby = :all)
 sel3 = make_selector(RenewableDispatch; name = "my_selector")
 ```
+
+See also: [`make_selector`](@ref) unified function documentation
 """
 make_selector(
     component_type::Type{<:InfrastructureSystemsComponent};
@@ -730,6 +738,8 @@ sel1 = make_selector(RenewableDispatch, x -> get_prime_mover_type(x) == PrimeMov
 sel2 = make_selector(RenewableDispatch, x -> get_prime_mover_type(x) == PrimeMovers.PVe; groupby = :all)
 sel3 = make_selector(RenewableDispatch, x -> get_prime_mover_type(x) == PrimeMovers.PVe; name = "my_selector")
 ```
+
+See also: [`make_selector`](@ref) unified function documentation
 """
 make_selector(
     filter_func::Function,

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -31,7 +31,7 @@ post-processing analytics (see e.g.
 [`PowerAnalytics.jl`](https://nrel-sienna.github.io/PowerAnalytics.jl/stable/)).
 
 Formally, instances of `ComponentSelector` represent lazy, partitioned, named,
-source-independent collections of `InfrastructureSystemsComponent`s.
+source-independent collections of [`InfrastructureSystemsComponent`](@ref)s.
 
 # Core Interface
 

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -160,6 +160,10 @@ specifies how the selector is grouped for the purposes of `get_groups`. The
     function's output.
 
 Other arguments are documented on a per-method basis.
+
+# Examples
+
+See the methods.
 """
 function make_selector end
 
@@ -167,6 +171,13 @@ function make_selector end
 """
 Get the name of the [`ComponentSelector`](@ref). This is either a user-specified name passed
 in at creation or a name automatically generated from the selector's specification.
+
+# Examples
+
+```julia
+sel = make_selector(RenewableDispatch)
+get_name(sel)  # "RenewableDispatch"
+```
 """
 get_name(selector::ComponentSelector) = selector.name
 
@@ -331,6 +342,7 @@ Returns a `ComponentSelector` functionally identical to the input `selector` exc
 changes to its fields specified in the keyword arguments.
 
 # Examples
+
 Suppose you have a selector with `name = "my_name`. If you instead wanted `name = "your_name`:
 ```julia
 sel = make_selector(ThermalStandard, "322_CT_6"; name = "my_name")
@@ -349,6 +361,7 @@ Returns a `ComponentSelector` functionally identical to the input `selector` exc
 changes to its fields specified in the keyword arguments.
 
 # Examples
+
 Suppose you have a selector with `groupby = :all`. If you instead wanted `groupby = :each`:
 ```julia
 sel = make_selector(ThermalStandard; groupby = :all)
@@ -402,6 +415,13 @@ it doesn't.
   - `component_name::AbstractString`: the name of the target component
   - `name::Union{String, Nothing} = nothing`: the name of the selector; if not provided, one
     will be constructed automatically
+
+# Examples
+
+```julia
+sel1 = make_selector(ThermalStandard, "322_CT_6")
+sel2 = make_selector(ThermalStandard, "322_CT_6"; name = "my_selector")
+```
 """
 make_selector(
     component_type::Type{<:InfrastructureSystemsComponent},
@@ -420,6 +440,13 @@ component exists and zero if it doesn't.
     the target of this selector
   - `name::Union{String, Nothing} = nothing`: the name of the selector; if not provided, one
     will be constructed automatically
+
+# Examples
+
+```julia
+sel1 = make_selector(my_component)
+sel2 = make_selector(my_component; name = "my_selector")
+```
 """
 make_selector(
     component::InfrastructureSystemsComponent;
@@ -495,6 +522,13 @@ of the selectors they were constructed with.
   - `content::ComponentSelector...`: the list of selectors that should form the groups
   - `name::Union{String, Nothing} = nothing`: the name of the selector; if not provided, one
     will be constructed automatically
+
+# Examples
+
+```julia
+sel1 = make_selector(make_selector(ThermalStandard), make_selector(RenewableDispatch))
+sel2 = make_selector(make_selector(ThermalStandard), make_selector(RenewableDispatch); name = "my_selector")
+```
 """
 make_selector(content::ComponentSelector...; name::Union{String, Nothing} = nothing) =
     ListComponentSelector(content, name)
@@ -544,6 +578,7 @@ changes to its fields specified in the keyword arguments. For `ListComponentSele
 instead of a `ListComponentSelector`.
 
 # Examples
+
 Suppose you have a selector with manual groups and you want to group by `:each`:
 ```julia
 sel = make_selector(make_selector(ThermalStandard), make_selector(RenewableDispatch))
@@ -601,6 +636,14 @@ components of the given type, grouped by the `groupby` argument (see the base
     [`make_selector`](@ref) documentation)
   - `name::Union{String, Nothing} = nothing`: the name of the selector; if not provided, one
     will be constructed automatically
+
+# Examples
+
+```julia
+sel1 = make_selector(RenewableDispatch)
+sel2 = make_selector(RenewableDispatch; groupby = :all)
+sel3 = make_selector(RenewableDispatch; name = "my_selector")
+```
 """
 make_selector(
     component_type::Type{<:InfrastructureSystemsComponent};
@@ -678,6 +721,14 @@ documentation).
     [`make_selector`](@ref) documentation)
   - `name::Union{String, Nothing} = nothing`: the name of the selector; if not provided, one
     will be constructed automatically
+
+# Examples
+
+```julia
+sel1 = make_selector(RenewableDispatch, x -> get_prime_mover_type(x) == PrimeMovers.PVe)
+sel2 = make_selector(RenewableDispatch, x -> get_prime_mover_type(x) == PrimeMovers.PVe; groupby = :all)
+sel3 = make_selector(RenewableDispatch, x -> get_prime_mover_type(x) == PrimeMovers.PVe; name = "my_selector")
+```
 """
 make_selector(
     filter_func::Function,

--- a/src/component_selector.jl
+++ b/src/component_selector.jl
@@ -194,13 +194,13 @@ Given a system-like source of component, get those components that make up the
 get_components(selector::ComponentSelector, sys) = get_components(nothing, selector, sys)
 
 """
-Get the single component that matches the `SingularComponentSelector`, or `nothing` if there
-is no match.
+Get the single component that matches the [`SingularComponentSelector`](@ref), or `nothing`
+if there is no match.
 
 # Arguments
 
-  - `selector::SingularComponentSelector`: the `ComponentSelector` that specifies which
-    component to get
+  - `selector::SingularComponentSelector`: the `SingularComponentSelector` that specifies
+    which component to get
   - `sys`: the system-like source of components to draw from
 """
 get_component(selector::SingularComponentSelector, sys) =
@@ -272,8 +272,8 @@ get_available_groups(selector::ComponentSelector, sys) =
     get_available_groups(nothing, selector, sys)
 
 """
-Make a `ComponentSelector` containing the components in `all_components` whose corresponding
-entry of `partition_results` matches `group_result`
+Make a [`ComponentSelector`](@ref) containing the components in `all_components` whose
+corresponding entry of `partition_results` matches `group_result`
 """
 function _make_group(all_components, partition_results, group_result, group_name)
     to_include = [isequal(p_res, group_result) for p_res in partition_results]
@@ -290,7 +290,7 @@ Given a system-like source of component, use the `groupby` property (see
 
   - `scope_limiter::Union{Function, Nothing}`: see [`ComponentSelector`](@ref)
   - `selector::DynamicallyGroupedComponentSelector`: the
-    `DynamicallyGroupedComponentSelector` whose groups should be retrieved
+    [`DynamicallyGroupedComponentSelector`](@ref) whose groups should be retrieved
   - `sys`: the system-like source of components to draw from
 """
 function get_groups(
@@ -319,7 +319,8 @@ function get_groups(
 end
 
 """
-Get the single group that corresponds to the `SingularComponentSelector`, i.e., itself.
+Get the single group that corresponds to the [`SingularComponentSelector`](@ref), i.e.,
+itself.
 
 # Arguments
 
@@ -338,12 +339,13 @@ get_groups(
 
 # Fallback `rebuild_selector` that only handles `name`
 """
-Returns a `ComponentSelector` functionally identical to the input `selector` except with the
-changes to its fields specified in the keyword arguments.
+Returns a [`ComponentSelector`](@ref) functionally identical to the input `selector` except
+with the changes to its fields specified in the keyword arguments.
 
 # Examples
 
-Suppose you have a selector with `name = "my_name`. If you instead wanted `name = "your_name`:
+Suppose you have a selector with `name = "my_name`. If you instead wanted `name =
+"your_name`:
 ```julia
 sel = make_selector(ThermalStandard, "322_CT_6"; name = "my_name")
 sel_yours = rebuild_selector(sel; name = "your_name")
@@ -357,8 +359,8 @@ function rebuild_selector(selector::T; name = nothing) where {T <: ComponentSele
 end
 
 """
-Returns a `ComponentSelector` functionally identical to the input `selector` except with the
-changes to its fields specified in the keyword arguments.
+Returns a [`ComponentSelector`](@ref) functionally identical to the input `selector` except
+with the changes to its fields specified in the keyword arguments.
 
 # Examples
 
@@ -456,8 +458,8 @@ make_selector(
 
 # Contents
 """
-Get the component to which the `NameComponentSelector` points, or `nothing` if such a
-component does not exist in `sys`.
+Get the component to which the [`NameComponentSelector`](@ref) points, or `nothing` if such
+a component does not exist in `sys`.
 
 # Arguments
 
@@ -477,7 +479,7 @@ function get_component(
 end
 
 """
-Get the components to which the `NameComponentSelector` points.
+Get the components to which the [`NameComponentSelector`](@ref) points.
 
 # Arguments
 
@@ -534,7 +536,7 @@ make_selector(content::ComponentSelector...; name::Union{String, Nothing} = noth
     ListComponentSelector(content, name)
 
 """
-Get the groups to which the `ListComponentSelector` points.
+Get the groups to which the [`ListComponentSelector`](@ref) points.
 
 # Arguments
 
@@ -548,7 +550,7 @@ function get_groups(::Union{Function, Nothing}, selector::ListComponentSelector,
 end
 
 """
-Get the components to which the `ListComponentSelector` points.
+Get the components to which the [`ListComponentSelector`](@ref) points.
 
 # Arguments
 
@@ -572,10 +574,9 @@ end
 
 # Rebuilding
 """
-Returns a `ComponentSelector` functionally identical to the input `selector` except with the
-changes to its fields specified in the keyword arguments. For `ListComponentSelector`, if a
-`groupby` option is specified, the return type will be a `RegroupedComponentSelector`
-instead of a `ListComponentSelector`.
+Returns a [`ComponentSelector`](@ref) functionally identical to the input `selector` except
+with the changes to its fields specified in the keyword arguments. It is not guaranteed that
+the result will have the same concrete type.
 
 # Examples
 
@@ -653,7 +654,7 @@ make_selector(
 
 # Contents
 """
-Get the components to which the `TypeComponentSelector` points.
+Get the components to which the [`TypeComponentSelector`](@ref) points.
 
 # Arguments
 
@@ -739,7 +740,7 @@ make_selector(
 
 # Contents
 """
-Get the components to which the `FilterComponentSelector` points.
+Get the components to which the [`FilterComponentSelector`](@ref) points.
 
 # Arguments
 
@@ -761,7 +762,7 @@ end
 
 # RegroupedComponentSelector
 """
-[`ComponentSelector`] that wraps another `ComponentSelector` and applies dynamic grouping.
+[`ComponentSelector`](@ref) that wraps another `ComponentSelector` and applies dynamic grouping.
 Components are the same as those of the wrapped selector, grouping is by the `groupby` field
 (see [`make_selector`](@ref))
 """
@@ -780,7 +781,7 @@ get_name(selector::RegroupedComponentSelector) = get_name(selector.wrapped_selec
 
 # Contents
 """
-Get the components to which the `RegroupedComponentSelector` points.
+Get the components to which the [`RegroupedComponentSelector`](@ref) points.
 
 # Arguments
 

--- a/src/components.jl
+++ b/src/components.jl
@@ -1,5 +1,6 @@
 const ComponentsByType = Dict{DataType, Dict{String, <:InfrastructureSystemsComponent}}
 
+"A simple container for components and time series data."
 struct Components <: ComponentContainer
     data::ComponentsByType
     time_series_manager::TimeSeriesManager

--- a/src/function_data.jl
+++ b/src/function_data.jl
@@ -358,7 +358,8 @@ deserialize(::Type{FunctionData}, val::Dict) =
 # PowerSimulations.
 
 """
-Get from a subtype or instance of FunctionData the type of data its get_raw_data method returns
+Get from a subtype or instance of FunctionData the type of data its `get_raw_data` method
+returns
 """
 function get_raw_data_type end
 get_raw_data_type(::Union{LinearFunctionData, Type{LinearFunctionData}}) =

--- a/src/hdf5_time_series_storage.jl
+++ b/src/hdf5_time_series_storage.jl
@@ -35,9 +35,9 @@ Constructs Hdf5TimeSeriesStorage.
   - `create_file::Bool`: create new file
   - `filename=nothing`: if nothing, create a temp file, else use this name.
   - `directory=nothing`: if set and filename is nothing, create a temp file in this
-    directory. If it is not set, use the environment variable SIENNA_TIME_SERIES_DIRECTORY.
-    If that is not set, use tempdir(). This should be set if the time series data is larger
-    than the tmp filesystem can hold.
+    directory. If it is not set, use the environment variable
+    `SIENNA_TIME_SERIES_DIRECTORY`. If that is not set, use tempdir(). This should be set if
+    the time series data is larger than the tmp filesystem can hold.
 """
 function Hdf5TimeSeriesStorage(
     create_file::Bool;

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -37,11 +37,11 @@ Construct SystemData to store components and time series data.
 
   - `validation_descriptor_file = nothing`: Optionally, a file defining component validation
     descriptors.
-  - `time_series_in_memory = false`: Controls whether time series data is stored in memory or
-    in a file.
-  - `time_series_directory = nothing`: Controls what directory time series data is stored in.
-    Default is the environment variable SIENNA_TIME_SERIES_DIRECTORY or tempdir() if that
-    isn't set.
+  - `time_series_in_memory = false`: Controls whether time series data is stored in memory
+    or in a file.
+  - `time_series_directory = nothing`: Controls what directory time series data is stored
+    in. Default is the environment variable `SIENNA_TIME_SERIES_DIRECTORY` or `tempdir()` if
+    that isn't set.
   - `compression = CompressionSettings()`: Controls compression of time series data.
 """
 function SystemData(;

--- a/src/time_series_cache.jl
+++ b/src/time_series_cache.jl
@@ -351,7 +351,7 @@ return a TimeSeries.TimeArray of size 1.
   - `component::InfrastructureSystemsComponent`: component
   - `name::AbstractString`: time series name
   - `cache_size_bytes = TIME_SERIES_CACHE_SIZE_BYTES`: maximum size of data to keep in memory
-  - `ignore_scaling_factors = false`: controls whether to ignore scaling_factor_multiplier
+  - `ignore_scaling_factors = false`: controls whether to ignore `scaling_factor_multiplier`
     in the time series instance
 """
 function StaticTimeSeriesCache(

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -814,15 +814,15 @@ references.
 
   - `dst::TimeSeriesOwners`: Destination owner
   - `src::TimeSeriesOwners`: Source owner
-  - `name_mapping::Dict = nothing`: Optionally map src names to different dst names.
-    If provided and src has a time_series with a name not present in name_mapping, that
-    time_series will not copied. If name_mapping is nothing then all time_series will be
-    copied with src's names.
+  - `name_mapping::Dict = nothing`: Optionally map src names to different dst names. If
+    provided and src has a `time_series` with a name not present in `name_mapping`, that
+    `time_series` will not copied. If `name_mapping` is nothing then all `time_series` will
+    be copied with src's names.
   - `scaling_factor_multiplier_mapping::Dict = nothing`: Optionally map src multipliers to
-    different dst multipliers.  If provided and src has a time_series with a multiplier not
-    present in scaling_factor_multiplier_mapping, that time_series will not copied. If
-    scaling_factor_multiplier_mapping is nothing then all time_series will be copied with
-    src's multipliers.
+    different dst multipliers.  If provided and src has a `time_series` with a multiplier
+    not present in `scaling_factor_multiplier_mapping`, that `time_series` will not copied.
+    If `scaling_factor_multiplier_mapping` is nothing then all `time_series` will be copied
+    with src's multipliers.
 """
 function copy_time_series!(
     dst::TimeSeriesOwners,

--- a/src/time_series_metadata_store.jl
+++ b/src/time_series_metadata_store.jl
@@ -1057,7 +1057,7 @@ end
 
 """
 Return information about each time series array attached to the owner.
-This information can be used to call get_time_series.
+This information can be used to call `get_time_series`.
 """
 function get_time_series_keys(store::TimeSeriesMetadataStore, owner::TimeSeriesOwners)
     return [make_time_series_key(x) for x in list_metadata(store, owner)]

--- a/src/utils/generate_structs.jl
+++ b/src/utils/generate_structs.jl
@@ -248,8 +248,8 @@ function generate_structs(
 end
 
 """
-Return true if the structs defined in existing_dir match structs freshly-generated
-from descriptor_file.
+Return true if the structs defined in `existing_dir` match structs freshly generated from
+`descriptor_file`.
 """
 function test_generated_structs(descriptor_file, existing_dir)
     output_dir = mktempdir()


### PR DESCRIPTION
Companion to https://github.com/NREL-Sienna/PowerSystems.jl/pull/1283 with the same goals.

Secondly, because it was bothering me, I endeavor to fix with backticks all instances of `_underscored_identifiers_` <- _underscored_identifiers_ spuriously rendering as italicized.