### PR TITLE
Get components attached to a supplemental attribute type

### DIFF
--- a/src/supplemental_attribute_associations.jl
+++ b/src/supplemental_attribute_associations.jl
@@ -238,7 +238,11 @@ function has_association(
     c_uuid = get_uuid(component)
     params = (string(a_uuid), string(c_uuid))
     return !isempty(
-        _execute_cached(associations, _QUERY_HAS_ASSOCIATION_BY_COMPONENT_ATTRIBUTE, params),
+        _execute_cached(
+            associations,
+            _QUERY_HAS_ASSOCIATION_BY_COMPONENT_ATTRIBUTE,
+            params,
+        ),
     )
 end
 

--- a/src/supplemental_attribute_associations.jl
+++ b/src/supplemental_attribute_associations.jl
@@ -200,7 +200,7 @@ function get_num_components_with_attributes(associations::SupplementalAttributeA
     return _execute_count(associations, query)
 end
 
-const _HAS_ASSOCIATION_BY_ATTRIBUTE = """
+const _QUERY_HAS_ASSOCIATION_BY_ATTRIBUTE = """
     SELECT attribute_uuid
     FROM $SUPPLEMENTAL_ATTRIBUTE_TABLE_NAME
     WHERE attribute_uuid = ?
@@ -218,12 +218,12 @@ function has_association(
     params = (string(get_uuid(attribute)),)
     return !isempty(
         Tables.rowtable(
-            _execute_cached(associations, _HAS_ASSOCIATION_BY_ATTRIBUTE, params),
+            _execute_cached(associations, _QUERY_HAS_ASSOCIATION_BY_ATTRIBUTE, params),
         ),
     )
 end
 
-const _HAS_ASSOCIATION_BY_COMPONENT_ATTRIBUTE = """
+const _QUERY_HAS_ASSOCIATION_BY_COMPONENT_ATTRIBUTE = """
     SELECT attribute_uuid
     FROM $SUPPLEMENTAL_ATTRIBUTE_TABLE_NAME
     WHERE attribute_uuid = ? AND component_uuid = ?
@@ -238,11 +238,11 @@ function has_association(
     c_uuid = get_uuid(component)
     params = (string(a_uuid), string(c_uuid))
     return !isempty(
-        _execute_cached(associations, _HAS_ASSOCIATION_BY_COMPONENT_ATTRIBUTE, params),
+        _execute_cached(associations, _QUERY_HAS_ASSOCIATION_BY_COMPONENT_ATTRIBUTE, params),
     )
 end
 
-const _HAS_ASSOCIATION_BY_COMPONENT = """
+const _QUERY_HAS_ASSOCIATION_BY_COMPONENT = """
     SELECT attribute_uuid
     FROM $SUPPLEMENTAL_ATTRIBUTE_TABLE_NAME
     WHERE component_uuid = ?
@@ -255,12 +255,12 @@ function has_association(
     params = (string(get_uuid(component)),)
     return !isempty(
         Tables.rowtable(
-            _execute_cached(associations, _HAS_ASSOCIATION_BY_COMPONENT, params),
+            _execute_cached(associations, _QUERY_HAS_ASSOCIATION_BY_COMPONENT, params),
         ),
     )
 end
 
-const _HAS_ASSOCIATION_BY_COMP_ATTR_TYPE = """
+const _QUERY_HAS_ASSOCIATION_BY_COMP_ATTR_TYPE = """
     SELECT attribute_uuid
     FROM $SUPPLEMENTAL_ATTRIBUTE_TABLE_NAME
     WHERE component_uuid = ? AND attribute_type = ?
@@ -274,12 +274,12 @@ function has_association(
     params = (string(get_uuid(component)), string(nameof(attribute_type)))
     return !isempty(
         Tables.rowtable(
-            _execute_cached(associations, _HAS_ASSOCIATION_BY_COMP_ATTR_TYPE, params),
+            _execute_cached(associations, _QUERY_HAS_ASSOCIATION_BY_COMP_ATTR_TYPE, params),
         ),
     )
 end
 
-const _LIST_ASSOCIATED_COMP_UUIDS = """
+const _QUERY_LIST_ASSOCIATED_COMP_UUIDS = """
     SELECT component_uuid
     FROM $SUPPLEMENTAL_ATTRIBUTE_TABLE_NAME
     WHERE attribute_uuid = ?
@@ -294,7 +294,7 @@ function list_associated_component_uuids(
 )
     params = (string(get_uuid(attribute)),)
     table = Tables.columntable(
-        _execute_cached(associations, _LIST_ASSOCIATED_COMP_UUIDS, params),
+        _execute_cached(associations, _QUERY_LIST_ASSOCIATED_COMP_UUIDS, params),
     )
     return Base.UUID.(table.component_uuid)
 end
@@ -314,7 +314,7 @@ function list_associated_component_uuids(
     return _list_associated_component_uuids(associations, subtypes)
 end
 
-const _LIST_ASSOCIATED_COMP_UUIDS_BY_ONE_TYPE = """
+const _QUERY_LIST_ASSOCIATED_COMP_UUIDS_BY_ONE_TYPE = """
     SELECT DISTINCT component_uuid
     FROM $SUPPLEMENTAL_ATTRIBUTE_TABLE_NAME
     WHERE attribute_type = ?
@@ -329,7 +329,7 @@ function _list_associated_component_uuids(
         # This would require an abstract type with no subtypes. Just here for completeness.
         return Base.UUID[]
     elseif len == 1
-        query = _LIST_ASSOCIATED_COMP_UUIDS_BY_ONE_TYPE
+        query = _QUERY_LIST_ASSOCIATED_COMP_UUIDS_BY_ONE_TYPE
         params = (string(nameof(first(attribute_types))),)
     else
         placeholder = chop(repeat("?,", length(attribute_types)))
@@ -401,7 +401,7 @@ function remove_associations!(
     return
 end
 
-const _REPLACE_COMP_UUID_SA = """
+const _QUERY_REPLACE_COMP_UUID_SA = """
     UPDATE $SUPPLEMENTAL_ATTRIBUTE_TABLE_NAME
     SET component_uuid = ?
     WHERE component_uuid = ?
@@ -416,7 +416,7 @@ function replace_component_uuid!(
     new_uuid::Base.UUID,
 )
     params = (string(new_uuid), string(old_uuid))
-    _execute_cached(associations, _REPLACE_COMP_UUID_SA, params)
+    _execute_cached(associations, _QUERY_REPLACE_COMP_UUID_SA, params)
     return
 end
 

--- a/src/supplemental_attribute_manager.jl
+++ b/src/supplemental_attribute_manager.jl
@@ -240,6 +240,12 @@ function get_supplemental_attribute(mgr::SupplementalAttributeManager, uuid::Bas
     throw(ArgumentError("No attribute with UUID = $uuid is stored"))
 end
 
+list_associated_component_uuids(
+    mgr::SupplementalAttributeManager,
+    attribute_type::Type{<:SupplementalAttribute},
+) =
+    list_associated_component_uuids(mgr.associations, attribute_type)
+
 function serialize(mgr::SupplementalAttributeManager)
     return Dict(
         "associations" => to_records(mgr.associations),

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -1057,7 +1057,7 @@ end
 get_components_by_name(::Type{T}, data::SystemData, args...) where {T} =
     get_components_by_name(T, data.components, args...)
 
-function get_components(data::SystemData, attribute::SupplementalAttribute)
+function get_associated_components(data::SystemData, attribute::SupplementalAttribute)
     [
         get_component(data, x) for x in list_associated_component_uuids(
             data.supplemental_attribute_manager.associations,
@@ -1066,10 +1066,32 @@ function get_components(data::SystemData, attribute::SupplementalAttribute)
     ]
 end
 
-get_components(filter_func::Function, data::SystemData, attribute::SupplementalAttribute) =
-    filter(filter_func, get_components(data, attribute))
+@deprecate get_components(data::SystemData, attribute::SupplementalAttribute) get_associated_components(
+    data,
+    attribute,
+)
 
-function get_components(data::SystemData, attribute_type::Type{<:SupplementalAttribute})
+get_associated_components(
+    filter_func::Function,
+    data::SystemData,
+    attribute::SupplementalAttribute,
+) =
+    filter(filter_func, get_associated_components(data, attribute))
+
+@deprecate get_components(
+    filter_func::Function,
+    data::SystemData,
+    attribute::SupplementalAttribute,
+) get_associated_components(
+    filter_func,
+    data,
+    attribute,
+)
+
+function get_associated_components(
+    data::SystemData,
+    attribute_type::Type{<:SupplementalAttribute},
+)
     return [
         get_component(data, x) for x in
         list_associated_component_uuids(data.supplemental_attribute_manager, attribute_type)

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -1066,10 +1066,11 @@ function get_associated_components(data::SystemData, attribute::SupplementalAttr
     ]
 end
 
-@deprecate get_components(data::SystemData, attribute::SupplementalAttribute) get_associated_components(
-    data,
-    attribute,
-)
+get_components(data::SystemData, attribute::SupplementalAttribute) =
+    get_associated_components(
+        data,
+        attribute,
+    )
 
 get_associated_components(
     filter_func::Function,
@@ -1078,11 +1079,11 @@ get_associated_components(
 ) =
     filter(filter_func, get_associated_components(data, attribute))
 
-@deprecate get_components(
+get_components(
     filter_func::Function,
     data::SystemData,
     attribute::SupplementalAttribute,
-) get_associated_components(
+) = get_associated_components(
     filter_func,
     data,
     attribute,

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -1069,6 +1069,13 @@ end
 get_components(filter_func::Function, data::SystemData, attribute::SupplementalAttribute) =
     filter(filter_func, get_components(data, attribute))
 
+function get_components(data::SystemData, attribute_type::Type{<:SupplementalAttribute})
+    return [
+        get_component(data, x) for x in
+        list_associated_component_uuids(data.supplemental_attribute_manager, attribute_type)
+    ]
+end
+
 function get_masked_components(
     ::Type{T},
     data::SystemData,

--- a/test/test_system_data.jl
+++ b/test/test_system_data.jl
@@ -507,7 +507,7 @@ end
     IS.add_component!(data, component2)
     IS.add_supplemental_attribute!(data, component1, geo_supplemental_attribute)
     IS.add_supplemental_attribute!(data, component2, geo_supplemental_attribute)
-    components = IS.get_components(data, geo_supplemental_attribute)
+    components = IS.get_associated_components(data, geo_supplemental_attribute)
     @test length(components) == 2
     sort!(components; by = x -> x.name)
     @test components[1] === component1
@@ -708,21 +708,21 @@ end
     end
     IS.add_supplemental_attribute!(data, component3, IS.TestSupplemental(; value = 5.0))
 
-    components = IS.get_components(data, IS.SupplementalAttribute)
+    components = IS.get_associated_components(data, IS.SupplementalAttribute)
     @test Set([IS.get_name(x) for x in components]) ==
           Set([IS.get_name(component1), IS.get_name(component2), IS.get_name(component3)])
 
-    components = IS.get_components(data, IS.GeographicInfo)
+    components = IS.get_associated_components(data, IS.GeographicInfo)
     @test Set([IS.get_name(x) for x in components]) ==
           Set([IS.get_name(component1), IS.get_name(component2)])
 
     IS.remove_supplemental_attributes!(data, IS.TestSupplemental)
-    @test isempty(IS.get_components(data, IS.TestSupplemental))
+    @test isempty(IS.get_associated_components(data, IS.TestSupplemental))
 
-    components = IS.get_components(data, IS.GeographicInfo)
+    components = IS.get_associated_components(data, IS.GeographicInfo)
     @test Set([IS.get_name(x) for x in components]) ==
           Set([IS.get_name(component1), IS.get_name(component2)])
 
     abstract type PointlessAbstractType <: IS.SupplementalAttribute end
-    @test isempty(IS.get_components(data, PointlessAbstractType))
+    @test isempty(IS.get_associated_components(data, PointlessAbstractType))
 end


### PR DESCRIPTION
This PR adds a feature that allows users to retrive components that are associated with one or more supplemental attributes of a given type. The type may be abstract or concrete.

```julia
components = IS.get_components(sys, IS.SupplementalAttribute)
components = IS.get_components(sys, IS.GeographicInfo)
```

Alternative points considered:
1. Some might argue that the type should be the first argument to the function. I put it second because (1) I find this more intuitive and (2) the Julia rule about types being first is related to returning an instance of that type (e.g., `parse(Int, "3")`). Also, consider this existing function:
```julia
function get_components(data::SystemData, attribute::SupplementalAttribute)
```
I think it's better for these two functions to look similar. That being said, if we just want types first, OK.

2. Use a different function name than `get_components` because we already have too many of those. I'm very sympathetic to this point. I chose to do this because of the function above.