### PR TITLE
Support irregular time series resolutions

### DIFF
--- a/src/deterministic_single_time_series.jl
+++ b/src/deterministic_single_time_series.jl
@@ -116,6 +116,7 @@ function get_window(
     initial_time::Dates.DateTime;
     len::Union{Nothing, Int} = nothing,
 )
+    # TODO DT: can interval be irregular?
     tdiff = Dates.Millisecond(initial_time - forecast.initial_timestamp)
     interval_ms = Dates.Millisecond(forecast.interval)
     if interval_ms != Dates.Millisecond(0) && tdiff % interval_ms != Dates.Millisecond(0)
@@ -214,6 +215,7 @@ function _translate_deterministic_offsets(
     columns,
     last_index,
 )
+    # TODO DT
     interval = Dates.Millisecond(interval)
     interval_offset = Int(interval / resolution)
     s_index = (columns.start - 1) * interval_offset + 1

--- a/src/forecasts.jl
+++ b/src/forecasts.jl
@@ -23,6 +23,7 @@ abstract type AbstractDeterministic <: Forecast end
 
 function check_time_series_data(forecast::Forecast)
     _check_forecast_data(forecast)
+    _check_forecast_interval(forecast)
     _check_forecast_windows(forecast)
 end
 
@@ -36,6 +37,11 @@ function _check_forecast_data(forecast::Forecast)
     length(lengths) != 1 &&
         throw(DimensionMismatch("All forecast arrays must have the same length"))
     return
+end
+
+function _check_forecast_interval(forecast::Forecast)
+    # TODO DT: test a failure case. We haven't been checking consistency of intervals.
+    check_resolution(collect(keys(get_data(forecast))), get_interval(forecast))
 end
 
 function _check_forecast_windows(forecast::Forecast)
@@ -52,6 +58,7 @@ function _check_forecast_windows(forecast::Forecast)
             )
         end
     end
+    return
 end
 
 # This method requires that the forecast type implement a `get_data` method like

--- a/src/probabilistic.jl
+++ b/src/probabilistic.jl
@@ -105,6 +105,9 @@ Construct Probabilistic from a Dict of TimeArrays.
   - `name::AbstractString`: user-defined name
   - `input_data::AbstractDict{Dates.DateTime, TimeSeries.TimeArray}`: time series data.
   - `percentiles`: Percentiles represented in the probabilistic forecast
+  - `resolution::Union{Nothing, Dates.Period} = nothing`: If nothing, infer resolution from the
+    data. Otherwise, this must be the difference between each consecutive timestamps. This is
+    required if the resolution is not constant, such as Dates.Month or Dates.Year.
   - `normalization_factor::NormalizationFactor = 1.0`: optional normalization factor to apply
     to each data entry
   - `scaling_factor_multiplier::Union{Nothing, Function} = nothing`: If the data are scaling
@@ -117,13 +120,14 @@ function Probabilistic(
     name::AbstractString,
     input_data::AbstractDict{Dates.DateTime, <:TimeSeries.TimeArray},
     percentiles::Vector{Float64};
+    resolution::Union{Nothing, Dates.Period} = nothing,
     normalization_factor::NormalizationFactor = 1.0,
     scaling_factor_multiplier::Union{Nothing, Function} = nothing,
 )
     data = SortedDict{Dates.DateTime, Matrix{Float64}}()
-    resolution =
-        TimeSeries.timestamp(first(values(input_data)))[2] -
-        TimeSeries.timestamp(first(values(input_data)))[1]
+    if isnothing(resolution)
+        resolution = get_resolution(first(values(input_data)))
+    end
     for (k, v) in input_data
         data[k] = TimeSeries.values(v)
     end

--- a/src/scenarios.jl
+++ b/src/scenarios.jl
@@ -95,6 +95,9 @@ Construct Scenarios from a Dict of TimeArrays.
 
   - `name::AbstractString`: user-defined name
   - `input_data::AbstractDict{Dates.DateTime, TimeSeries.TimeArray}`: time series data.
+  - `resolution::Union{Nothing, Dates.Period} = nothing`: If nothing, infer resolution from the
+    data. Otherwise, this must be the difference between each consecutive timestamps. This is
+    required if the resolution is not constant, such as Dates.Month or Dates.Year.
   - `normalization_factor::NormalizationFactor = 1.0`: optional normalization factor to apply
     to each data entry
   - `scaling_factor_multiplier::Union{Nothing, Function} = nothing`: If the data are scaling
@@ -106,13 +109,14 @@ Construct Scenarios from a Dict of TimeArrays.
 function Scenarios(
     name::AbstractString,
     input_data::AbstractDict{Dates.DateTime, <:TimeSeries.TimeArray};
+    resolution::Union{Nothing, Dates.Period} = nothing,
     normalization_factor::NormalizationFactor = 1.0,
     scaling_factor_multiplier::Union{Nothing, Function} = nothing,
 )
     data = SortedDict{Dates.DateTime, Matrix{Float64}}()
-    resolution =
-        TimeSeries.timestamp(first(values(input_data)))[2] -
-        TimeSeries.timestamp(first(values(input_data)))[1]
+    if isnothing(resolution)
+        resolution = get_resolution(first(values(input_data)))
+    end
     for (k, v) in input_data
         data[k] = TimeSeries.values(v)
     end

--- a/src/single_time_series.jl
+++ b/src/single_time_series.jl
@@ -36,15 +36,20 @@ end
 function SingleTimeSeries(;
     name,
     data,
+    resolution::Union{Nothing, Dates.Period} = nothing,
     scaling_factor_multiplier = nothing,
     normalization_factor = 1.0,
     internal = InfrastructureSystemsInternal(),
 )
+    # TODO DT: if the data has irregular resolution but resolution is nothing, we should throw. 
+    if isnothing(resolution)
+        resolution = get_resolution(data)
+    end
     data = handle_normalization_factor(data, normalization_factor)
     return SingleTimeSeries(
         name,
         data,
-        get_resolution(data),
+        resolution,
         scaling_factor_multiplier,
         internal,
     )
@@ -84,15 +89,19 @@ Construct SingleTimeSeries from a TimeArray or DataFrame.
   - `scaling_factor_multiplier::Union{Nothing, Function} = nothing`: If the data are scaling
     factors then this function will be called on the component and applied to the data when
     [`get_time_series_array`](@ref) is called.
-  - `timestamp = :timestamp`: If a DataFrame is passed then this must be the column name that
+  - `timestamp::Symbol = :timestamp`: If a DataFrame is passed then this must be the column name that
     contains timestamps.
+  - `resolution::Union{Nothing, Dates.Period} = nothing`: If nothing, infer resolution from the
+    data. Otherwise, this must be the difference between each consecutive timestamps. This is
+    required if the resolution is not constant, such as Dates.Month or Dates.Year.
 """
 function SingleTimeSeries(
     name::AbstractString,
     data::Union{TimeSeries.TimeArray, DataFrames.DataFrame};
     normalization_factor::NormalizationFactor = 1.0,
     scaling_factor_multiplier::Union{Nothing, Function} = nothing,
-    timestamp = :timestamp,
+    timestamp::Symbol = :timestamp,
+    resolution::Union{Nothing, Dates.Period} = nothing,
 )
     if data isa DataFrames.DataFrame
         ta = TimeSeries.TimeArray(data; timestamp = timestamp)
@@ -105,6 +114,7 @@ function SingleTimeSeries(
     return SingleTimeSeries(;
         name = name,
         data = ta,
+        resolution = resolution,
         scaling_factor_multiplier = scaling_factor_multiplier,
         normalization_factor = normalization_factor,
         internal = InfrastructureSystemsInternal(),
@@ -214,13 +224,8 @@ end
 function check_time_series_data(ts::SingleTimeSeries)
     len = length(ts.data)
     len < 2 && throw(ArgumentError("data array length must be at least 2: $len"))
-    timestamps = TimeSeries.timestamp(ts.data)
-    for i in 2:len
-        res = timestamps[i] - timestamps[i - 1]
-        if res != ts.resolution
-            throw(ConflictingInputsError("resolution mismatch: $res $ts.resolution"))
-        end
-    end
+    check_resolution(TimeSeries.timestamp(ts.data), ts.resolution)
+    return
 end
 
 """

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -1032,10 +1032,11 @@ end
 _get_columns(start_time, count, ts_metadata::StaticTimeSeriesMetadata) = UnitRange(1, 1)
 
 function _get_rows(start_time, len, ts_metadata::StaticTimeSeriesMetadata)
-    index =
-        Int(
-            (start_time - get_initial_timestamp(ts_metadata)) / get_resolution(ts_metadata),
-        ) + 1
+    index = compute_time_array_index(
+        get_initial_timestamp(ts_metadata),
+        start_time,
+        get_resolution(ts_metadata),
+    )
     if len === nothing
         len = length(ts_metadata) - index + 1
     end
@@ -1066,6 +1067,7 @@ function _check_start_time(start_time, metadata::ForecastMetadata)
     actual_start_time = _check_start_time_common(start_time, metadata)
     window_count = get_count(metadata)
     interval = get_interval(metadata)
+    # TODO DT
     time_diff = actual_start_time - get_initial_timestamp(metadata)
     if window_count > 1 &&
        Dates.Millisecond(time_diff) % Dates.Millisecond(interval) != Dates.Second(0)
@@ -1128,6 +1130,7 @@ function get_forecast_window_count(
         last_initial_time = last_timestamp - resolution * (horizon_count - 1)
 
         # Reduce last_initial_time to the nearest interval if necessary.
+        # TODO DT
         diff =
             Dates.Millisecond(last_initial_time - initial_timestamp) %
             Dates.Millisecond(interval)

--- a/src/time_series_metadata_store.jl
+++ b/src/time_series_metadata_store.jl
@@ -59,7 +59,7 @@ function TimeSeriesMetadataStore(filename::AbstractString)
         _migrate_legacy_schema(store)
     end
 
-    _apply_horizon_type_fix_if_needed(store.db)
+    # _apply_horizon_type_fix_if_needed(store.db)
     _load_metadata_into_memory!(store)
     _create_indexes!(store)
     @debug "Loaded time series metadata from file" _group = LOG_GROUP_TIME_SERIES filename
@@ -150,9 +150,9 @@ function _migrate_legacy_schema(store::TimeSeriesMetadataStore)
                     ,time_series_type
                     ,time_series_category
                     ,initial_timestamp
-                    ,resolution_ms
-                    ,horizon_ms
-                    ,interval_ms
+                    ,resolution
+                    ,horizon
+                    ,interval
                     ,window_count
                     ,length
                     ,name
@@ -194,9 +194,9 @@ function _migrate_legacy_schema(store::TimeSeriesMetadataStore)
             "time_series_type",
             "time_series_category",
             "initial_timestamp",
-            "resolution_ms",
-            "horizon_ms",
-            "interval_ms",
+            "resolution",
+            "horizon",
+            "interval",
             "window_count",
             "length",
             "name",
@@ -247,9 +247,9 @@ function _create_associations_table!(store::TimeSeriesMetadataStore)
         "time_series_type TEXT NOT NULL",
         "time_series_category TEXT NOT NULL",
         "initial_timestamp TEXT NOT NULL",
-        "resolution_ms INTEGER NOT NULL",
-        "horizon_ms INTEGER",
-        "interval_ms INTEGER",
+        "resolution TEXT NOT NULL",
+        "horizon TEXT",
+        "interval TEXT",
         "window_count INTEGER",
         "length INTEGER",
         "name TEXT NOT NULL",
@@ -292,9 +292,10 @@ function _create_indexes!(store::TimeSeriesMetadataStore)
     # 2. Optimize for checks at system.add_time_series. Use all fields and features.
     # 3. Optimize for returning all metadata for a time series UUID.
     # resolution_ms was added in v2.4.4.
+    # and dropped in XXX
     if "by_c_n_tst_features" in
        SQLite.indices(store.db).name && !(
-        "resolution_ms" in
+        "resolution" in
         sql(store, "PRAGMA index_info('by_c_n_tst_features')")[!, "name"]
     )
         SQLite.dropindex!(store.db, "by_c_n_tst_features"; ifexists = true)
@@ -303,7 +304,7 @@ function _create_indexes!(store::TimeSeriesMetadataStore)
         store.db,
         ASSOCIATIONS_TABLE_NAME,
         "by_c_n_tst_features",
-        ["owner_uuid", "time_series_type", "name", "resolution_ms", "features"];
+        ["owner_uuid", "time_series_type", "name", "resolution", "features"];
         unique = true,
         ifnotexists = true,
     )
@@ -500,13 +501,13 @@ end
 
 const _GET_FORECAST_PARAMS = """
     SELECT
-        horizon_ms
+        horizon
         ,initial_timestamp
-        ,interval_ms
-        ,resolution_ms
+        ,interval
+        ,resolution
         ,window_count
     FROM $ASSOCIATIONS_TABLE_NAME
-    WHERE horizon_ms IS NOT NULL
+    WHERE horizon IS NOT NULL
     LIMIT 1
 """
 function get_forecast_parameters(store::TimeSeriesMetadataStore)
@@ -514,11 +515,11 @@ function get_forecast_parameters(store::TimeSeriesMetadataStore)
     isempty(table) && return nothing
     row = table[1]
     return ForecastParameters(;
-        horizon = Dates.Millisecond(row.horizon_ms),
+        horizon = from_string(row.horizon),
         initial_timestamp = Dates.DateTime(row.initial_timestamp),
-        interval = Dates.Millisecond(row.interval_ms),
+        interval = from_string(row.interval),
         count = row.window_count,
-        resolution = Dates.Millisecond(row.resolution_ms),
+        resolution = from_string(row.resolution),
     )
 end
 
@@ -537,13 +538,13 @@ end
 function get_forecast_horizon(store::TimeSeriesMetadataStore)
     query = """
         SELECT
-            horizon_ms
+            horizon
         FROM $ASSOCIATIONS_TABLE_NAME
-        WHERE horizon_ms IS NOT NULL
+        WHERE horizon IS NOT NULL
         LIMIT 1
         """
     table = Tables.rowtable(_execute_cached(store, query))
-    return isempty(table) ? nothing : Dates.Millisecond(table[1].horizon_ms)
+    return isempty(table) ? nothing : from_string(table[1].horizon)
 end
 
 function get_forecast_initial_timestamp(store::TimeSeriesMetadataStore)
@@ -551,7 +552,7 @@ function get_forecast_initial_timestamp(store::TimeSeriesMetadataStore)
         SELECT
             initial_timestamp
         FROM $ASSOCIATIONS_TABLE_NAME
-        WHERE horizon_ms IS NOT NULL
+        WHERE horizon IS NOT NULL
         LIMIT 1
         """
     table = Tables.rowtable(_execute_cached(store, query))
@@ -565,16 +566,16 @@ end
 function get_forecast_interval(store::TimeSeriesMetadataStore)
     query = """
         SELECT
-            interval_ms
+            interval
         FROM $ASSOCIATIONS_TABLE_NAME
-        WHERE interval_ms IS NOT NULL
+        WHERE interval IS NOT NULL
         LIMIT 1
         """
     table = Tables.rowtable(_execute_cached(store, query))
     return if isempty(table)
         nothing
     else
-        Dates.Millisecond(table[1].interval_ms)
+        from_string(table[1].interval)
     end
 end
 
@@ -650,13 +651,13 @@ function get_time_series_counts(store::TimeSeriesMetadataStore)
         SELECT
             COUNT(DISTINCT time_series_uuid) AS count
         FROM $ASSOCIATIONS_TABLE_NAME
-        WHERE interval_ms IS NULL
+        WHERE interval IS NULL
     """
     query_forecasts = """
         SELECT
             COUNT(DISTINCT time_series_uuid) AS count
         FROM $ASSOCIATIONS_TABLE_NAME
-        WHERE interval_ms IS NOT NULL
+        WHERE interval IS NOT NULL
     """
 
     count_components = _execute_count(store, query_components)
@@ -703,7 +704,7 @@ function get_static_time_series_summary_table(store::TimeSeriesMetadataStore)
             ,owner_category
             ,time_series_type
             ,initial_timestamp
-            ,resolution_ms AS resolution
+            ,resolution AS resolution
             ,count(*) AS count
             ,length AS time_step_count
         FROM $ASSOCIATIONS_TABLE_NAME
@@ -713,19 +714,19 @@ function get_static_time_series_summary_table(store::TimeSeriesMetadataStore)
             ,owner_category
             ,time_series_type
             ,initial_timestamp
-            ,resolution_ms
+            ,resolution
             ,length
         ORDER BY
             owner_category
             ,owner_type
             ,time_series_type
             ,initial_timestamp
-            ,resolution_ms
+            ,resolution
             ,length
     """
     query_result = DataFrame(_execute(store, query))
     query_result[!, "resolution"] =
-        Dates.canonicalize.(Dates.Millisecond.(query_result[!, "resolution"]))
+        Dates.canonicalize.(from_string.(query_result[!, "resolution"]))
     return query_result
 end
 
@@ -740,10 +741,10 @@ function get_forecast_summary_table(store::TimeSeriesMetadataStore)
             ,owner_category
             ,time_series_type
             ,initial_timestamp
-            ,resolution_ms AS resolution
+            ,resolution AS resolution
             ,count(*) AS count
-            ,horizon_ms AS horizon
-            ,interval_ms AS interval
+            ,horizon AS horizon
+            ,interval AS interval
             ,window_count
         FROM $ASSOCIATIONS_TABLE_NAME
         WHERE time_series_category = "$(_get_time_series_category(Forecast))"
@@ -752,24 +753,24 @@ function get_forecast_summary_table(store::TimeSeriesMetadataStore)
             ,owner_category
             ,time_series_type
             ,initial_timestamp
-            ,resolution_ms
-            ,horizon_ms
-            ,interval_ms
+            ,resolution
+            ,horizon
+            ,interval
             ,window_count
         ORDER BY
             owner_category
             ,owner_type
             ,time_series_type
             ,initial_timestamp
-            ,resolution_ms
-            ,horizon_ms
-            ,interval_ms
+            ,resolution
+            ,horizon
+            ,interval
             ,window_count
     """
     query_result = DataFrame(_execute(store, query))
     for col_name in ["resolution", "horizon", "interval"]
         query_result[!, col_name] =
-            Dates.canonicalize.(Dates.Millisecond.(query_result[!, col_name]))
+            Dates.canonicalize.(from_string.(query_result[!, col_name]))
     end
     return query_result
 end
@@ -858,7 +859,7 @@ function _make_has_metadata_statement!(
         push!(where_clauses, "time_series_type IN ($val)")
     end
     if key.has_resolution
-        push!(where_clauses, "resolution_ms = ?")
+        push!(where_clauses, "resolution = ?")
     end
     if key.has_features
         if isnothing(key.feature_filter)
@@ -899,7 +900,8 @@ end
 _get_name_params(::Nothing) = ()
 _get_name_params(name::String) = (name,)
 _get_resolution_param(::Nothing) = ()
-_get_resolution_param(x::Dates.Period) = (Dates.Millisecond(x).value,)
+_get_resolution_param(x::Dates.Period) =
+    (to_string(is_constant_period(x) ? Dates.Millisecond(x) : x),)
 _get_ts_type_params(::Nothing) = ()
 _get_ts_type_params(ts_type::Type{<:TimeSeriesData}) =
     (_convert_ts_type_to_string(ts_type),)
@@ -945,12 +947,12 @@ function get_time_series_resolutions(
     end
     query = """
         SELECT
-            DISTINCT resolution_ms
+            DISTINCT resolution
         FROM $ASSOCIATIONS_TABLE_NAME $where_clause
-        ORDER BY resolution_ms
+        ORDER BY resolution
     """
-    return Dates.Millisecond.(
-        Tables.columntable(_execute(store, query, params)).resolution_ms
+    return from_string.(
+        Tables.columntable(_execute(store, query, params)).resolution
     )
 end
 
@@ -1068,8 +1070,8 @@ function list_owner_uuids_with_time_series(
         push!(params, string(nameof(time_series_type)))
     end
     if !isnothing(resolution)
-        push!(vals, "resolution_ms = ?")
-        push!(params, Dates.Millisecond(resolution).value)
+        push!(vals, "resolution = ?")
+        push!(params, _serialize_period(resolution))
     end
 
     where_clause = join(vals, " AND ")
@@ -1206,9 +1208,9 @@ function _create_row(
         ts_type,
         ts_category,
         string(get_initial_timestamp(metadata)),
-        Dates.Millisecond(get_resolution(metadata)).value,
-        Dates.Millisecond(get_horizon(metadata)).value,
-        Dates.Millisecond(get_interval(metadata)).value,
+        _serialize_period(get_resolution(metadata)),
+        _serialize_period(get_horizon(metadata)),
+        _serialize_period(get_interval(metadata)),
         get_count(metadata),
         missing,
         get_name(metadata),
@@ -1228,13 +1230,17 @@ function _create_row(
     ts_category,
     features,
 )
+    resolution = get_resolution(metadata)
+    if is_constant_period(resolution)
+        resolution = Dates.Millisecond(resolution)
+    end
     return (
         missing,  # auto-assigned by sqlite
         string(get_time_series_uuid(metadata)),
         ts_type,
         ts_category,
         string(get_initial_timestamp(metadata)),
-        Dates.Millisecond(get_resolution(metadata)).value,
+        _serialize_period(get_resolution(metadata)),
         missing,
         missing,
         missing,
@@ -1246,6 +1252,13 @@ function _create_row(
         features,
         string(get_uuid(metadata)),
     )
+end
+
+function _serialize_period(period::Dates.Period)
+    if is_constant_period(period)
+        period = Dates.Millisecond(period)
+    end
+    return to_string(period)
 end
 
 function make_stmt(store::TimeSeriesMetadataStore, query::String)
@@ -1434,8 +1447,8 @@ function _make_where_clause(;
         push!(params, name)
     end
     if !isnothing(resolution)
-        push!(vals, "resolution_ms = ?")
-        push!(params, Dates.Millisecond(resolution).value)
+        push!(vals, "resolution = ?")
+        push!(params, _serialize_period(resolution))
     end
     num_possible_types = _get_num_possible_types(time_series_type)
     if num_possible_types == 1

--- a/src/time_series_utils.jl
+++ b/src/time_series_utils.jl
@@ -17,3 +17,251 @@ is_time_series_sub_type(::Type{DeterministicMetadata}, ::Type{AbstractDeterminis
 is_time_series_sub_type(::Type{DeterministicMetadata}, ::Type{Forecast}) = true
 is_time_series_sub_type(::Type{ProbabilisticMetadata}, ::Type{Forecast}) = true
 is_time_series_sub_type(::Type{ScenariosMetadata}, ::Type{Forecast}) = true
+
+function check_resolution(ts::TimeSeries.TimeArray)
+    error("TODO DT: we don't want this method")
+    tstamps = TimeSeries.timestamp(ts)
+    timediffs = unique([tstamps[ix] - tstamps[ix - 1] for ix in 2:length(tstamps)])
+    res = []
+    for timediff in timediffs
+        if mod(timediff, Dates.Millisecond(Dates.Day(1))) == Dates.Millisecond(0)
+            push!(res, Dates.Day(timediff / Dates.Millisecond(Dates.Day(1))))
+        elseif mod(timediff, Dates.Millisecond(Dates.Hour(1))) == Dates.Millisecond(0)
+            push!(res, Dates.Hour(timediff / Dates.Millisecond(Dates.Hour(1))))
+        elseif mod(timediff, Dates.Millisecond(Dates.Minute(1))) == Dates.Millisecond(0)
+            push!(res, Dates.Minute(timediff / Dates.Millisecond(Dates.Minute(1))))
+        elseif mod(timediff, Dates.Millisecond(Dates.Second(1))) == Dates.Millisecond(0)
+            push!(res, Dates.Second(timediff / Dates.Millisecond(Dates.Second(1))))
+        else
+            throw(DataFormatError("cannot understand the resolution of the time series"))
+        end
+    end
+
+    if length(res) > 1
+        throw(
+            DataFormatError(
+                "time series has non-uniform resolution: this is currently not supported",
+            ),
+        )
+    end
+
+    return res[1]
+end
+
+"""
+Check if the timestamps have a constant resolution.
+Handles constant periods like Second and Minute as well as irregular periods like Month and Year.
+Relies on the _calendrical_ arithmetic of the Julia's Dates library.
+https://docs.julialang.org/en/v1/stdlib/Dates/#TimeType-Period-Arithmetic
+
+# Arguments
+- `timestamps`: An indexable sequence of DateTime values
+- `resolution`: a Dates.Period value
+"""
+function check_resolution(timestamps, resolution::Dates.Period)
+    # Note this behavior in Julia:
+    # julia> DateTime("2020-02-01T00:00:00") + Month(1)
+    # 2020-03-01T00:00:00
+    for i in 2:length(timestamps)
+        if timestamps[i] != timestamps[i - 1] + resolution
+            throw(
+                ConflictingInputsError(
+                    "resolution mismatch: $timestamps[i - 1] $timestamps[i] $resolution",
+                ),
+            )
+        end
+    end
+end
+
+function get_initial_timestamp(data::TimeSeries.TimeArray)
+    return TimeSeries.timestamp(data)[1]
+end
+
+function get_initial_times(
+    initial_timestamp::Dates.DateTime,
+    count::Int,
+    interval::Dates.Period,
+)
+    if count == 0
+        return []
+    elseif interval == Dates.Second(0)
+        return [initial_timestamp]
+    end
+
+    return range(initial_timestamp; length = count, step = interval)
+end
+
+"""
+Given a series of timestamps that start with initial_time and increment by resolution,
+return the index of other time in the array of timestamps.
+
+# Examples
+```julia
+julia> compute_time_array_index(
+    DateTime("2024-01-01T00:00:00"),
+    DateTime("2024-01-01T05:00:00"),
+    Hour(1),
+)
+6
+julia> compute_time_array_index(
+    DateTime("2024-01-01T00:00:00"),
+    DateTime("2024-04-01T00:00:00"),
+    Month(1),
+)
+4
+julia> compute_time_array_index(
+    DateTime("2024-01-01T00:00:00"),
+    DateTime("2028-01-01T00:00:00"),
+    Year(1),
+)
+5
+```
+"""
+function compute_time_array_index(
+    initial_time::Dates.DateTime,
+    other_time::Dates.DateTime,
+    resolution::Dates.Period,
+)
+    initial_time == other_time && return 1
+    num_periods = compute_periods_between(initial_time, other_time, resolution)
+    index = num_periods + 1
+    return index
+end
+
+"""
+Given a series of timestamps that increment by period, return the number of periods
+between t1 and t2.
+
+t2 must be greater than or equal to t1.
+There must be an even number of periods between t1 and t2.
+period can be regular (e.g., Hour) or irregular (e.g., Month).
+
+# Arguments
+- `t1`: The initial timestamp.
+- `t2`: The second timestamp.
+- `period`: The period to use for the index.
+
+# Examples
+```julia
+julia> compute_periods_between(
+    DateTime("2024-01-01T00:00:00"),
+    DateTime("2024-01-01T05:00:00"),
+    Hour(1),
+)
+5
+julia> compute_period_index(
+    DateTime("2024-02-01T00:00:00"),
+    DateTime("2024-04-01T00:00:00"),
+    Month(1),
+)
+2
+julia> compute_period_index(
+    DateTime("2024-01-01T00:00:00"),
+    DateTime("2028-01-01T00:00:00"),
+    Year(1),
+)
+4
+```
+"""
+function compute_periods_between(
+    t1::Dates.DateTime,
+    t2::Dates.DateTime,
+    period::Dates.Period,
+)
+    time_diff = t2 - t1
+    return _compute_periods_between_common(t1, t2, period, time_diff, Dates.Millisecond(0))
+end
+
+function compute_periods_between(
+    t1::Dates.DateTime,
+    t2::Dates.DateTime,
+    period::Dates.Month,
+)
+    year1, month1 = Dates.yearmonth(t1)
+    year2, month2 = Dates.yearmonth(t2)
+    time_diff = (year2 - year1) * 12 + (month2 - month1)
+    return _compute_periods_between_common(t1, t2, Dates.value(period), time_diff, 0)
+end
+
+function compute_periods_between(
+    t1::Dates.DateTime,
+    t2::Dates.DateTime,
+    period::Dates.Quarter,
+)
+    year1 = Dates.year(t1)
+    quarter1 = Dates.quarter(t1)
+    year2 = Dates.year(t2)
+    quarter2 = Dates.quarter(t2)
+    time_diff = (year2 - year1) * 4 + (quarter2 - quarter1)
+    return _compute_periods_between_common(t1, t2, Dates.value(period), time_diff, 0)
+end
+
+function compute_periods_between(t1::Dates.DateTime, t2::Dates.DateTime, period::Dates.Year)
+    time_diff = Dates.year(t2) - Dates.year(t1)
+    return _compute_periods_between_common(t1, t2, Dates.value(period), time_diff, 0)
+end
+
+function _compute_periods_between_common(
+    t1::Dates.DateTime,
+    t2::Dates.DateTime,
+    period,
+    time_diff,
+    zero_val,
+)
+    if t1 > t2
+        throw(ArgumentError("t1 must be less than t2"))
+    end
+
+    if time_diff % period != zero_val
+        throw(ArgumentError("$t2 - $t1 is not evenly divisible by $period"))
+    end
+
+    return time_diff ÷ period
+end
+
+"""
+Return the resolution from a TimeArray.
+"""
+function get_resolution(ts::TimeSeries.TimeArray)
+    if length(ts) < 2
+        throw(ConflictingInputsError("Resolution can't be inferred from the data."))
+    end
+
+    timestamps = TimeSeries.timestamp(ts)
+    return timestamps[2] - timestamps[1]
+end
+
+function get_total_period(
+    initial_timestamp::Dates.DateTime,
+    count::Int,
+    interval::Dates.Period,
+    horizon::Dates.Period,
+    resolution::Dates.Period,
+)
+    horizon_count = get_horizon_count(horizon, resolution)
+    last_it = initial_timestamp + interval * count
+    last_timestamp = last_it + resolution * (horizon_count - 1)
+    return last_timestamp - initial_timestamp
+end
+
+# These functions allow us to preserve type and value of periods in databases and files.
+# We are not using string(period) because the Dates package behaves differently for
+# singular vs plural and uses lower case. This is simpler.
+
+to_string(period::Dates.Period) = "$(period.value) $(nameof(typeof(period)))"
+
+function from_string(period::String)
+    parts = split(period, " ")
+    if length(parts) != 2
+        throw(ArgumentError("Invalid period string: $period"))
+    end
+
+    value = parse(Int, parts[1])
+    period_type = Symbol(parts[2])
+    return getproperty(Dates, period_type)(value)
+end
+
+is_constant_period(period::Dates.Period) = true
+is_constant_period(period::Dates.Month) = false
+is_constant_period(period::Dates.Year) = false
+is_constant_period(period::Dates.Quarter) = false

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -381,51 +381,6 @@ macro forward(sender, receiver, exclusions = Symbol[])
     return esc(out)
 end
 
-"""
-Return the resolution from a TimeArray.
-"""
-function get_resolution(ts::TimeSeries.TimeArray)
-    if length(ts) < 2
-        throw(ConflictingInputsError("Resolution can't be inferred from the data."))
-    end
-
-    timestamps = TimeSeries.timestamp(ts)
-    return timestamps[2] - timestamps[1]
-end
-
-function check_resolution(ts::TimeSeries.TimeArray)
-    tstamps = TimeSeries.timestamp(ts)
-    timediffs = unique([tstamps[ix] - tstamps[ix - 1] for ix in 2:length(tstamps)])
-    res = []
-    for timediff in timediffs
-        if mod(timediff, Dates.Millisecond(Dates.Day(1))) == Dates.Millisecond(0)
-            push!(res, Dates.Day(timediff / Dates.Millisecond(Dates.Day(1))))
-        elseif mod(timediff, Dates.Millisecond(Dates.Hour(1))) == Dates.Millisecond(0)
-            push!(res, Dates.Hour(timediff / Dates.Millisecond(Dates.Hour(1))))
-        elseif mod(timediff, Dates.Millisecond(Dates.Minute(1))) == Dates.Millisecond(0)
-            push!(res, Dates.Minute(timediff / Dates.Millisecond(Dates.Minute(1))))
-        elseif mod(timediff, Dates.Millisecond(Dates.Second(1))) == Dates.Millisecond(0)
-            push!(res, Dates.Second(timediff / Dates.Millisecond(Dates.Second(1))))
-        else
-            throw(DataFormatError("cannot understand the resolution of the time series"))
-        end
-    end
-
-    if length(res) > 1
-        throw(
-            DataFormatError(
-                "time series has non-uniform resolution: this is currently not supported",
-            ),
-        )
-    end
-
-    return res[1]
-end
-
-function get_initial_timestamp(data::TimeSeries.TimeArray)
-    return TimeSeries.timestamp(data)[1]
-end
-
 # Looking up modules with Base.root_module is slow; cache them.
 const g_cached_modules = Dict{String, Module}()
 
@@ -461,33 +416,6 @@ function copy_file(src::AbstractString, dst::AbstractString)
         run(`cp -f $(src_path) $(dst_path)`)
     end
     return
-end
-
-function get_initial_times(
-    initial_timestamp::Dates.DateTime,
-    count::Int,
-    interval::Dates.Period,
-)
-    if count == 0
-        return []
-    elseif interval == Dates.Second(0)
-        return [initial_timestamp]
-    end
-
-    return range(initial_timestamp; length = count, step = interval)
-end
-
-function get_total_period(
-    initial_timestamp::Dates.DateTime,
-    count::Int,
-    interval::Dates.Period,
-    horizon::Dates.Period,
-    resolution::Dates.Period,
-)
-    horizon_count = get_horizon_count(horizon, resolution)
-    last_it = initial_timestamp + interval * count
-    last_timestamp = last_it + resolution * (horizon_count - 1)
-    return last_timestamp - initial_timestamp
 end
 
 function transform_array_for_hdf(data::SortedDict{Dates.DateTime, Vector{CONSTANT}})

--- a/test/InfrastructureSystemsTests.jl
+++ b/test/InfrastructureSystemsTests.jl
@@ -2,7 +2,7 @@ module InfrastructureSystemsTests
 
 using ReTest
 using Logging
-import Dates
+using Dates
 import TerminalLoggers: TerminalLogger
 import TimeSeries
 import UUIDs

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -427,6 +427,33 @@ end
     IS.add_time_series!(sys, component, data)
 end
 
+@testset "Test add SingleTimeSeries with irregular resolution." begin
+    sys = IS.SystemData()
+    name = "Component1"
+    component = IS.TestComponent(name, 5)
+    IS.add_component!(sys, component)
+
+    initial_time = Dates.DateTime("2020-01-01")
+    resolution = Dates.Month(1)
+
+    data = TimeSeries.TimeArray(range(initial_time; length = 12, step = resolution), 1:12)
+    ts_name = "ts"
+    ts1 = IS.SingleTimeSeries(; data = data, name = ts_name, resolution = resolution)
+    IS.add_time_series!(sys, component, ts1)
+
+    ts2_full = IS.get_time_series(IS.SingleTimeSeries, component, ts_name)
+    @test IS.get_data(ts2_full) == IS.get_data(ts1)
+
+    ts2_partial = IS.get_time_series(
+        IS.SingleTimeSeries,
+        component,
+        ts_name;
+        start_time = initial_time + resolution * 6,
+        len = 6,
+    )
+    @test IS.get_data(ts2_partial) == IS.get_data(ts1)[7:end]
+end
+
 @testset "Test add SingleTimeSeries with features" begin
     sys = IS.SystemData()
     name = "Component1"

--- a/test/test_time_series_utils.jl
+++ b/test/test_time_series_utils.jl
@@ -1,0 +1,137 @@
+@testset "Test check_resolution" begin
+    timestamps = [
+        DateTime("2023-01-01T00:00:00"),
+        DateTime("2023-01-01T00:01:00"),
+        DateTime("2023-01-01T00:02:00"),
+        DateTime("2023-01-01T00:03:00"),
+    ]
+    resolution = Minute(1)
+    IS.check_resolution(timestamps, resolution)
+
+    timestamps = [
+        DateTime("2023-01-01T00:00:00"),
+        DateTime("2023-01-01T00:01:00"),
+        DateTime("2023-01-01T00:02:00"),
+        DateTime("2023-01-01T00:04:00"),
+    ]
+    resolution = Minute(1)
+    @test_throws IS.ConflictingInputsError IS.check_resolution(timestamps, resolution)
+
+    timestamps = [
+        DateTime("2023-01-01T00:00:00"),
+        DateTime("2023-02-01T00:00:00"),
+        DateTime("2023-03-01T00:00:00"),
+        DateTime("2023-04-01T00:00:00"),
+    ]
+    resolution = Month(1)
+    IS.check_resolution(timestamps, resolution)
+
+    timestamps = [
+        DateTime("2023-01-01T00:00:00"),
+        DateTime("2023-02-01T00:00:00"),
+        DateTime("2023-03-01T00:00:00"),
+        DateTime("2023-04-02T00:00:00"),
+    ]
+    resolution = Month(1)
+    @test_throws IS.ConflictingInputsError IS.check_resolution(timestamps, resolution)
+end
+
+@testset "Test get_resolution" begin
+    timestamps = [
+        DateTime("2023-01-01T00:00:00"),
+        DateTime("2023-01-01T00:01:00"),
+        DateTime("2023-01-01T00:02:00"),
+        DateTime("2023-01-01T00:03:00"),
+    ]
+    ts = TimeSeries.TimeArray(timestamps, rand(length(timestamps)))
+    @test IS.get_resolution(ts) == Minute(1)
+
+    timestamps = [
+        DateTime("2023-01-01T00:00:00"),
+        DateTime("2023-02-01T00:00:00"),
+        DateTime("2023-03-01T00:00:00"),
+        DateTime("2023-04-01T00:00:00"),
+    ]
+    ts = TimeSeries.TimeArray(timestamps, rand(length(timestamps)))
+    @test IS.get_resolution(ts) != Month(1)
+
+    timestamps = [
+        DateTime("2023-01-01T00:00:00"),
+    ]
+    ts = TimeSeries.TimeArray(timestamps, rand(length(timestamps)))
+    @test_throws IS.ConflictingInputsError IS.get_resolution(ts)
+end
+
+@testset "Test period to_string" begin
+    @test IS.from_string(IS.to_string(Hour(1))) == Hour(1)
+    @test IS.from_string(IS.to_string(Minute(5))) == Minute(5)
+    @test IS.from_string(IS.to_string(Month(1))) == Month(1)
+end
+
+@testset "Test is_constant_period" begin
+    all_periods = Set(IS.get_all_concrete_subtypes(Period))
+    constant_periods = (
+        Day,
+        Week,
+        Hour,
+        Microsecond,
+        Millisecond,
+        Minute,
+        Nanosecond,
+        Second,
+    )
+    non_constant_periods = (
+        Month,
+        Quarter,
+        Year,
+    )
+
+    # Ensure that we find out about new Period types.
+    @test isempty(setdiff(all_periods, union(constant_periods, non_constant_periods)))
+
+    for period_type in constant_periods
+        @test IS.is_constant_period(period_type(5))
+    end
+    for period_type in non_constant_periods
+        @test !IS.is_constant_period(period_type(5))
+    end
+end
+
+@testset "Test compute_time_array_index" begin
+    @test IS.compute_time_array_index(
+        DateTime(2024, 1, 1),
+        DateTime(2024, 1, 2),
+        Minute(5),
+    ) == 289
+    @test IS.compute_time_array_index(
+        DateTime(2024, 1, 1),
+        DateTime(2024, 1, 1, 5),
+        Hour(1),
+    ) == 6
+    @test IS.compute_time_array_index(
+        DateTime(2024, 1, 1),
+        DateTime(2024, 12, 1),
+        Month(1),
+    ) == 12
+    @test IS.compute_time_array_index(
+        DateTime(2024, 1, 1),
+        DateTime(2025, 1, 1),
+        Month(2),
+    ) == 7
+    @test IS.compute_time_array_index(
+        DateTime(2024, 1, 1),
+        DateTime(2024, 10, 1),
+        Quarter(1),
+    ) == 4
+    @test IS.compute_time_array_index(
+        DateTime(2024, 1, 1),
+        DateTime(2034, 1, 1),
+        Year(1),
+    ) == 11
+
+    @test_throws ArgumentError IS.compute_time_array_index(
+        DateTime(2024, 1, 1),
+        DateTime(2024, 1, 1, 5, 30),
+        Hour(1),
+    ) == 6
+end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -53,22 +53,3 @@ IS.get_name(::FakeTimeSeries) = "fake"
         sprint(show, MIME("text/plain"), summary(FakeTimeSeries())),
     )
 end
-
-@testset "Test check_resolution" begin
-    initial_time1 = Dates.DateTime("2020-09-01")
-    len1 = 24
-    resolution1 = Dates.Hour(1)
-    timestamps1 = range(initial_time1; length = len1, step = resolution1)
-    ta1 = TimeSeries.TimeArray(timestamps1, rand(len1))
-    IS.check_resolution(ta1) == resolution1
-
-    initial_time2 = Dates.DateTime("2020-09-02")
-    len2 = 12
-    resolution2 = Dates.Minute(5)
-    timestamps2 = range(initial_time2; length = len2, step = resolution2)
-    ta2 = TimeSeries.TimeArray(timestamps2, rand(len2))
-    IS.check_resolution(ta2) == resolution2
-
-    ta3 = vcat(ta1, ta2)
-    @test_throws IS.DataFormatError IS.check_resolution(ta3)
-end


### PR DESCRIPTION
This draft PR demonstrates how we could support irregular time series resolutions, such as `Dates.Month` and `Dates.Year`. The main problem with the current code is that it converts timestamps in a time series array to indexes by calculating `(t2 - t1) / resolution`, which doesn't work with subtypes of `Dates.Period` that cannot be converted to milliseconds.

There are a few questions that need resolution before we can proceed.
1. When a user passes a `TimeSeries.TimeArray` to the `SingleTimeSeries` constructor, we compute the resolution for the user by subtracting the first two timestamps. Can we require that the user pass resolution when that resolution is irregular? Otherwise, we would have to make a guess when the resolution is about a month or year, or some multiple of those.
2. Can the fields `horizon` and `interval` also be irregular?

## TODOs
- [ ] Perform database migration because this code changes the data type for resolution, and maybe horizon and interval.
- [ ] Add tests for all cases 
- [ ] TODOs in the code