### PR TITLE
Implement non-allocating `@scoped_enum`

### DIFF
--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -256,14 +256,15 @@ julia> @scoped_enum(Fruit,
 ```
 """
 macro scoped_enum(T, args...)
-    hn_methods = []
-    n2v_methods = []
-    v2n_methods = []
-    for p in args
-        value = Int64(last(p.args))
-        push!(hn_methods, :(_hasname(::$(Val{first(p.args)})) = true))
-        push!(n2v_methods, :(_name2value(::$(Val{first(p.args)})) = $value))
-        push!(v2n_methods, :(_value2name(::Val{$value}) = $(String(first(p.args)))))
+    hn_methods = Array{Expr}(undef, length(args))
+    n2v_methods = Array{Expr}(undef, length(args))
+    v2n_methods = Array{Expr}(undef, length(args))
+    for (i, p) in enumerate(args)
+        _ValKey = Val{first(p.args)}
+        _value = Int64(last(p.args))
+        hn_methods[i] = :(_hasname(::$_ValKey) = true)
+        n2v_methods[i] = :(_name2value(::$_ValKey) = $_value)
+        v2n_methods[i] = :(_value2name(::Val{$_value}) = $(String(first(p.args))))
     end
     blk = esc(
         :(

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -20,7 +20,7 @@ end
 
 IS.@scoped_enum Fruit APPLE = 1 ORANGE = 2
 
-@testset "Test scoped_enum" begin
+@testset "Test scoped_enum correctness" begin
     @test Fruit.APPLE isa Fruit
     @test Fruit.ORANGE isa Fruit
     @test sort([Fruit.ORANGE, Fruit.APPLE]) == [Fruit.APPLE, Fruit.ORANGE]
@@ -35,6 +35,12 @@ IS.@scoped_enum Fruit APPLE = 1 ORANGE = 2
 
     @test IS.deserialize_struct(Foo, IS.serialize_struct(Foo(Fruit.APPLE))) ==
           Foo(Fruit.APPLE)
+end
+
+@testset "Test scoped_enum performance" begin
+    # TODO figure out why this fails if evaluated inside a testset that defines a struct
+    @test iszero(@allocated Fruit.APPLE)
+    @test iszero(@allocated instances(Fruit))
 end
 
 @testset "Test undef component prints" begin


### PR DESCRIPTION
The fundamental problem behind https://github.com/NREL-Sienna/PowerSystems.jl/pull/1216 is that `@scoped_enum` is backed by a `Dict`, which is mutable, so we can't compile away the lookup even in cases where it looks like a constant (e.g., `my_units == UnitSystem.NATURAL_UNITS`). There is no notion of a "constant dictionary" in Julia. However, a dictionary is just a function with a very small domain, and `Val`-based function application is more amenable to compile-time optimization. Here, I use that idea to implement a non-allocating `@scoped_enum`. This should eliminate the need for `@scoped_enum` users to implement their own patchwork fixes like https://github.com/NREL-Sienna/PowerSystems.jl/pull/1216 when they need performance.

Draft because I'm not confident that this is the right approach: I've tested that it doesn't allocate, but I still need to test other aspects of performance. Also, this is not how `@enum` is implemented in `@Base`, maybe an implementation along those lines would be even better.