### PR TITLE
Add function get_base_component_type

### DIFF
--- a/src/component_container.jl
+++ b/src/component_container.jl
@@ -22,6 +22,9 @@ abstract type ComponentContainer <: InfrastructureSystemsContainer end
 # The notion of availability used in `get_available` and `get_available_component(s)` is up
 # to the subtype, but it must be consistent across the three functions.
 
+"Return the base type stored in the container."
+get_base_component_type(::ComponentContainer) = InfrastructureSystemsComponent
+
 "Get an iterator of components of a certain specification from the `ComponentContainer`."
 function get_components end
 
@@ -76,10 +79,10 @@ get_available_component(sys::ComponentContainer, args...; kwargs...) =
 
 # Satisfy the InfrastructureSystemsContainer interface
 iterate_container(sys::ComponentContainer) =
-    get_components(InfrastructureSystemsComponent, sys)
+    get_components(get_base_component_type(sys), sys)
 
 get_num_members(sys::ComponentContainer) =
-    length(get_components(InfrastructureSystemsComponent, sys))
+    length(get_components(get_base_component_type(sys), sys))
 
 # This alias is helpful because ComponentContainers like PSY.System contain other types
 # like supplemental attributes and time series.


### PR DESCRIPTION
This new function will allow parent types to use all default methods in ComponentContainer.